### PR TITLE
fix: incomplete `<boltAction>` tag issue (again)

### DIFF
--- a/app/lib/.server/llm/utils.ts
+++ b/app/lib/.server/llm/utils.ts
@@ -3,9 +3,6 @@ import { DEFAULT_MODEL, DEFAULT_PROVIDER, MODEL_REGEX, PROVIDER_REGEX } from '~/
 import { IGNORE_PATTERNS, type FileMap } from './constants';
 import ignore from 'ignore';
 import type { ContextAnnotation } from '~/types/context';
-import { createScopedLogger } from '~/utils/logger';
-
-const logger = createScopedLogger('LLM:Utils');
 
 export function extractPropertiesFromMessage(message: Omit<Message, 'id'>): {
   model: string;
@@ -48,34 +45,6 @@ export function extractPropertiesFromMessage(message: Omit<Message, 'id'>): {
 }
 
 export function simplifyBoltActions(input: string): string {
-  // Handle incomplete boltAction tags
-  const incompleteOpenTagRegex = /<boltAction[^>]*$/;
-
-  if (incompleteOpenTagRegex.test(input)) {
-    logger.debug('Found incomplete boltAction tag:', input.match(incompleteOpenTagRegex)?.[0]);
-    input = input.replace(incompleteOpenTagRegex, '');
-    logger.debug('Removed incomplete boltAction tag');
-  }
-
-  // Handle incomplete tag starts (e.g., ending with '<boltAc')
-  const incompleteStartRegex = /<bolt(?:Action|Artifact)?$/;
-
-  if (incompleteStartRegex.test(input)) {
-    logger.debug('Found incomplete bolt tag start:', input.match(incompleteStartRegex)?.[0]);
-    input = input.replace(incompleteStartRegex, '');
-    logger.debug('Removed incomplete bolt tag start');
-  }
-
-  // Handle open tags without closing tags
-  const openWithoutCloseRegex = /(<boltAction[^>]*>)([^<]*)$/;
-  const openMatch = input.match(openWithoutCloseRegex);
-
-  if (openMatch) {
-    logger.debug('Found open tag without closing tag:', openMatch[0]);
-    input = input.replace(openWithoutCloseRegex, '');
-    logger.debug('Removed open tag without closing tag');
-  }
-
   // Using regex to match boltAction tags that have type="file"
   const regex = /(<boltAction[^>]*type="file"[^>]*>)([\s\S]*?)(<\/boltAction>)/g;
 

--- a/app/lib/runtime/message-parser.ts
+++ b/app/lib/runtime/message-parser.ts
@@ -88,9 +88,6 @@ export class StreamingMessageParser {
       this.#messages.set(messageId, state);
     }
 
-    // Care about incomplete tags
-    input = this.#sanitizeIncompleteActionTags(input);
-
     let output = '';
     let i = state.position;
     let earlyBreak = false;
@@ -314,39 +311,6 @@ export class StreamingMessageParser {
   #extractAttribute(tag: string, attributeName: string): string | undefined {
     const match = tag.match(new RegExp(`${attributeName}="([^"]*)"`, 'i'));
     return match ? match[1] : undefined;
-  }
-
-  #sanitizeIncompleteActionTags(input: string): string {
-    // Check for open boltAction tags without closing tags
-    const openTagRegex = /<boltAction[^>]*>([\s\S]*)$/;
-    const openMatch = input.match(openTagRegex);
-
-    if (openMatch && !input.includes('</boltAction>')) {
-      // Log when incomplete tag is detected
-      logger.warn('Detected and handled incomplete boltAction tag due to token limit');
-      logger.debug('Original input with incomplete tag:', input);
-
-      // Safely remove the incomplete tag
-      const sanitized = input.replace(openTagRegex, '');
-      logger.debug('After removing incomplete tag:', sanitized);
-
-      return sanitized;
-    }
-
-    // Handle incomplete tag starts (e.g., ending with '<boltAc')
-    const incompleteStartRegex = /<bolt(?:Action|Artifact)?$/;
-
-    if (incompleteStartRegex.test(input)) {
-      logger.warn('Detected and handled incomplete bolt tag start due to token limit');
-      logger.debug('Original input with incomplete tag start:', input);
-
-      const sanitized = input.replace(incompleteStartRegex, '');
-      logger.debug('After removing incomplete tag start:', sanitized);
-
-      return sanitized;
-    }
-
-    return input;
   }
 }
 

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -10,7 +10,7 @@ import { getFilePaths, selectContext } from '~/lib/.server/llm/select-context';
 import type { ContextAnnotation, ProgressAnnotation } from '~/types/context';
 import { WORK_DIR } from '~/utils/constants';
 import { createSummary } from '~/lib/.server/llm/create-summary';
-import { extractPropertiesFromMessage, simplifyBoltActions } from '~/lib/.server/llm/utils';
+import { extractPropertiesFromMessage } from '~/lib/.server/llm/utils';
 import { searchVectorDB } from '~/lib/.server/llm/search-vectordb';
 import { searchResources } from '~/lib/.server/llm/search-resources';
 
@@ -306,16 +306,10 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
             const switchesLeft = MAX_RESPONSE_SEGMENTS - stream.switches;
 
             logger.info(`Reached max token limit (${MAX_TOKENS}): Continuing message (${switchesLeft} switches left)`);
-            logger.debug('Last chunk before sanitizing due to token limit:', content.slice(-100));
 
             const lastUserMessage = messages.filter((x) => x.role == 'user').slice(-1)[0];
             const { model, provider } = extractPropertiesFromMessage(lastUserMessage);
-
-            // Safely handle truncated response caused by token limit
-            const sanitizedContent = simplifyBoltActions(content);
-            logger.debug('Sanitized content after token limit:', sanitizedContent.slice(-100));
-
-            messages.push({ id: generateId(), role: 'assistant', content: sanitizedContent });
+            messages.push({ id: generateId(), role: 'assistant', content });
             messages.push({
               id: generateId(),
               role: 'user',


### PR DESCRIPTION
This PR reverts #20 and fixes #19 by ~assigning `user` role to previous context properly~ forcibly performing the previous action when new tag is coming into the message parser.