### PR TITLE
fix: eliminate duplicated string in multipart message

### DIFF
--- a/app/components/chat/AssistantMessage.tsx
+++ b/app/components/chat/AssistantMessage.tsx
@@ -4,6 +4,7 @@ import type { JSONValue } from 'ai';
 import Popover from '~/components/ui/Popover';
 import { workbenchStore } from '~/lib/stores/workbench';
 import { WORK_DIR } from '~/utils/constants';
+import React from 'react';
 
 interface AssistantMessageProps {
   content: string;
@@ -75,10 +76,10 @@ export const AssistantMessage = memo(({ content, annotations }: AssistantMessage
                     <div className="code-context flex flex-col p4 border border-bolt-elements-borderColor rounded-md">
                       <h2>Context</h2>
                       <div className="flex gap-4 mt-4 bolt" style={{ zoom: 0.6 }}>
-                        {codeContext.map((x) => {
+                        {codeContext.map((x, index) => {
                           const normalized = normalizedFilePath(x);
                           return (
-                            <>
+                            <React.Fragment key={normalized || index}>
                               <code
                                 className="bg-bolt-elements-artifacts-inlineCode-background text-bolt-elements-artifacts-inlineCode-text px-1.5 py-1 rounded-md text-bolt-elements-item-contentAccent hover:underline cursor-pointer"
                                 onClick={(e) => {
@@ -89,7 +90,7 @@ export const AssistantMessage = memo(({ content, annotations }: AssistantMessage
                               >
                                 {normalized}
                               </code>
-                            </>
+                            </React.Fragment>
                           );
                         })}
                       </div>

--- a/app/components/chat/Messages.client.tsx
+++ b/app/components/chat/Messages.client.tsx
@@ -51,7 +51,7 @@ export const Messages = forwardRef<HTMLDivElement, MessagesProps>(
       <div id={id} className={props.className} ref={ref}>
         {messages.length > 0
           ? messages.map((message, index) => {
-              const { role, content, id: messageId, annotations } = message;
+              const { role, id: messageId, annotations } = message;
               const isUserMessage = role === 'user';
               const isFirst = index === 0;
               const isLast = index === messages.length - 1;
@@ -60,6 +60,15 @@ export const Messages = forwardRef<HTMLDivElement, MessagesProps>(
               if (isHidden) {
                 return <Fragment key={index} />;
               }
+
+              // `message.content` has an internal problem of duplicating strings for multipart message.
+              const content =
+                message.parts && message.parts.length > 1
+                  ? message.parts
+                      .filter((part) => part.type === 'text')
+                      .map((part) => part.text)
+                      .join('')
+                  : message.content;
 
               return (
                 <div


### PR DESCRIPTION
Note) this PR should be merged after #42.

This PR fixes invalid message rendering for multipart message while streaming.