### PR TITLE
fix: `boltArtfiact` parsing

### DIFF
--- a/app/components/chat/Messages.client.tsx
+++ b/app/components/chat/Messages.client.tsx
@@ -61,15 +61,6 @@ export const Messages = forwardRef<HTMLDivElement, MessagesProps>(
                 return <Fragment key={index} />;
               }
 
-              // `message.content` has an internal problem of duplicating strings for multipart message.
-              const content =
-                message.parts && message.parts.length > 1
-                  ? message.parts
-                      .filter((part) => part.type === 'text')
-                      .map((part) => part.text)
-                      .join('')
-                  : message.content;
-
               return (
                 <div
                   key={index}
@@ -97,9 +88,9 @@ export const Messages = forwardRef<HTMLDivElement, MessagesProps>(
                   )}
                   <div className="grid grid-col-1 w-full">
                     {isUserMessage ? (
-                      <UserMessage content={content} />
+                      <UserMessage content={message.content} />
                     ) : (
-                      <AssistantMessage content={content} annotations={message.annotations} />
+                      <AssistantMessage content={message.content} annotations={message.annotations} />
                     )}
                   </div>
                   {!isUserMessage && (

--- a/app/lib/.server/llm/create-summary.ts
+++ b/app/lib/.server/llm/create-summary.ts
@@ -4,6 +4,7 @@ import { DEFAULT_MODEL, DEFAULT_PROVIDER, PROVIDER_LIST } from '~/utils/constant
 import { extractCurrentContext, extractPropertiesFromMessage, simplifyBoltActions } from './utils';
 import { createScopedLogger } from '~/utils/logger';
 import { LLMManager } from '~/lib/modules/llm/manager';
+import { extractTextContent } from '~/utils/message';
 
 const logger = createScopedLogger('create-summary');
 
@@ -94,11 +95,6 @@ ${summary.summary}`;
   }
 
   logger.debug('Sliced Messages:', slicedMessages.length);
-
-  const extractTextContent = (message: Message) =>
-    Array.isArray(message.content)
-      ? (message.content.find((item) => item.type === 'text')?.text as string) || ''
-      : message.content;
 
   // select files from the list of code file from the project that might be useful for the current request from the user
   const resp = await generateText({

--- a/app/lib/.server/llm/search-resources.ts
+++ b/app/lib/.server/llm/search-resources.ts
@@ -7,6 +7,7 @@ import { createScopedLogger } from '~/utils/logger';
 import { LLMManager } from '~/lib/modules/llm/manager';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createClient } from '@supabase/supabase-js';
+import { extractTextContent } from '~/utils/message';
 
 const logger = createScopedLogger('search-resources');
 
@@ -309,11 +310,6 @@ export async function searchResources(props: {
       modelDetails = modelsList[0];
     }
   }
-
-  const extractTextContent = (message: Message) =>
-    Array.isArray(message.content)
-      ? (message.content.find((item) => item.type === 'text')?.text as string) || ''
-      : message.content;
 
   const lastUserMessage = processedMessages.filter((x) => x.role == 'user').pop();
 

--- a/app/lib/.server/llm/search-vectordb.ts
+++ b/app/lib/.server/llm/search-vectordb.ts
@@ -8,6 +8,7 @@ import { createScopedLogger } from '~/utils/logger';
 import { LLMManager } from '~/lib/modules/llm/manager';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createClient } from '@supabase/supabase-js';
+import { extractTextContent } from '~/utils/message';
 
 // Common patterns to ignore, similar to .gitignore
 const ig = ignore().add(IGNORE_PATTERNS);
@@ -334,11 +335,6 @@ export async function searchVectorDB(props: {
       modelDetails = modelsList[0];
     }
   }
-
-  const extractTextContent = (message: Message) =>
-    Array.isArray(message.content)
-      ? (message.content.find((item) => item.type === 'text')?.text as string) || ''
-      : message.content;
 
   const lastUserMessage = processedMessages.filter((x) => x.role == 'user').pop();
 

--- a/app/lib/.server/llm/select-context.ts
+++ b/app/lib/.server/llm/select-context.ts
@@ -6,6 +6,7 @@ import { DEFAULT_MODEL, DEFAULT_PROVIDER, PROVIDER_LIST } from '~/utils/constant
 import { createFilesContext, extractCurrentContext, extractPropertiesFromMessage, simplifyBoltActions } from './utils';
 import { createScopedLogger } from '~/utils/logger';
 import { LLMManager } from '~/lib/modules/llm/manager';
+import { extractTextContent } from '~/utils/message';
 
 // Common patterns to ignore, similar to .gitignore
 
@@ -109,11 +110,6 @@ export async function selectContext(props: {
   }
 
   const summaryText = `Here is the summary of the chat till now: ${summary}`;
-
-  const extractTextContent = (message: Message) =>
-    Array.isArray(message.content)
-      ? (message.content.find((item) => item.type === 'text')?.text as string) || ''
-      : message.content;
 
   const lastUserMessage = processedMessages.filter((x) => x.role == 'user').pop();
 

--- a/app/lib/hooks/useMessageParser.ts
+++ b/app/lib/hooks/useMessageParser.ts
@@ -43,8 +43,11 @@ const messageParser = new StreamingMessageParser({
   },
 });
 const extractTextContent = (message: Message) =>
-  Array.isArray(message.content)
-    ? (message.content.find((item) => item.type === 'text')?.text as string) || ''
+  message.parts && message.parts.length > 0
+    ? message.parts
+        .filter((part) => part.type === 'text')
+        .map((part) => part.text)
+        .join('')
     : message.content;
 
 export function useMessageParser() {

--- a/app/lib/hooks/useMessageParser.ts
+++ b/app/lib/hooks/useMessageParser.ts
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'react';
 import { StreamingMessageParser } from '~/lib/runtime/message-parser';
 import { workbenchStore } from '~/lib/stores/workbench';
 import { createScopedLogger } from '~/utils/logger';
+import { extractTextContent } from '~/utils/message';
 
 const logger = createScopedLogger('useMessageParser');
 
@@ -42,13 +43,6 @@ const messageParser = new StreamingMessageParser({
     },
   },
 });
-const extractTextContent = (message: Message) =>
-  message.parts && message.parts.length > 0
-    ? message.parts
-        .filter((part) => part.type === 'text')
-        .map((part) => part.text)
-        .join('')
-    : message.content;
 
 export function useMessageParser() {
   const [parsedMessages, setParsedMessages] = useState<{ [key: number]: string }>({});

--- a/app/utils/message.ts
+++ b/app/utils/message.ts
@@ -1,0 +1,9 @@
+import type { Message } from 'ai';
+
+export const extractTextContent = (message: Message) =>
+  message.parts && message.parts.length > 0
+    ? message.parts
+        .filter((part) => part.type === 'text')
+        .map((part) => part.text)
+        .join('')
+    : message.content;


### PR DESCRIPTION
Continued from #44 

This PR moves `message.parts` consideration from `Message.client.tsx` to `useMessageParser.ts`, to parse `message.parts` too.