### PR TITLE
fix: duplicate contents on the multipart messages (again)

### DIFF
--- a/app/lib/hooks/useMessageParser.ts
+++ b/app/lib/hooks/useMessageParser.ts
@@ -58,10 +58,45 @@ export function useMessageParser() {
     for (const [index, message] of messages.entries()) {
       if (message.role === 'assistant' || message.role === 'user') {
         const newParsedContent = messageParser.parse(message.id, extractTextContent(message));
-        setParsedMessages((prevParsed) => ({
-          ...prevParsed,
-          [index]: !reset ? (prevParsed[index] || '') + newParsedContent : newParsedContent,
-        }));
+
+        /**
+         * KNOWN ISSUE: When a new part is added to a message, the message ID can change
+         * (see: https://github.com/vercel/ai/issues/5318)
+         *
+         * This causes messageParser.parse() to produce duplicate content. The logic below
+         * handles this by checking for overlapping content between the existing parsed content
+         * and the new content being added. This is a workaround until the underlying issue
+         * with message IDs changing is fixed in the AI library.
+         */
+        const updateParsedMessages = function (prevParsed: { [key: number]: string }) {
+          const updatedMessages = { ...prevParsed };
+          const existingContent = prevParsed[index] || '';
+
+          if (!reset) {
+            let finalContent = existingContent + newParsedContent;
+
+            if (existingContent.length > 0 && newParsedContent.length > 0) {
+              const maxCheckLength = Math.min(existingContent.length, newParsedContent.length);
+
+              for (let i = 1; i <= maxCheckLength; i++) {
+                const tailOfExisting = existingContent.slice(-i);
+                const headOfNew = newParsedContent.slice(0, i);
+
+                if (tailOfExisting === headOfNew) {
+                  finalContent = existingContent + newParsedContent.slice(i);
+                }
+              }
+            }
+
+            updatedMessages[index] = finalContent;
+          } else {
+            updatedMessages[index] = newParsedContent;
+          }
+
+          return updatedMessages;
+        };
+
+        setParsedMessages(updateParsedMessages);
       }
     }
   }, []);

--- a/app/utils/logger.ts
+++ b/app/utils/logger.ts
@@ -44,6 +44,11 @@ function setLevel(level: DebugLevel) {
   currentLevel = level;
 }
 
+function formatTime(): string {
+  const now = new Date();
+  return now.toTimeString().split(' ')[0] + '.' + now.getMilliseconds().toString().padStart(3, '0');
+}
+
 function log(level: DebugLevel, scope: string | undefined, messages: any[]) {
   const levelOrder: DebugLevel[] = ['trace', 'debug', 'info', 'warn', 'error'];
 
@@ -68,6 +73,7 @@ function log(level: DebugLevel, scope: string | undefined, messages: any[]) {
 
   const labelStyles = getLabelStyles(labelBackgroundColor, labelTextColor);
   const scopeStyles = getLabelStyles('#77828D', 'white');
+  const timeStyles = getLabelStyles('#555555', 'white');
 
   const styles = [labelStyles];
 
@@ -75,14 +81,27 @@ function log(level: DebugLevel, scope: string | undefined, messages: any[]) {
     styles.push('', scopeStyles);
   }
 
+  styles.push('', timeStyles);
+
+  const timeString = formatTime();
+  const timeLabel = formatText(` ${timeString} `, '#FFFFFF', '#555555');
+
   let labelText = formatText(` ${level.toUpperCase()} `, labelTextColor, labelBackgroundColor);
 
   if (scope) {
     labelText = `${labelText} ${formatText(` ${scope} `, '#FFFFFF', '77828D')}`;
   }
 
+  labelText = `${timeLabel} ${labelText}`;
+
   if (typeof window !== 'undefined') {
-    console.log(`%c${level.toUpperCase()}${scope ? `%c %c${scope}` : ''}`, ...styles, allMessages);
+    console.log(
+      `%c${timeString}%c ${level.toUpperCase()}${scope ? `%c %c${scope}` : ''}`,
+      timeStyles,
+      labelStyles,
+      ...styles.slice(2),
+      allMessages,
+    );
   } else {
     console.log(`${labelText}`, allMessages);
   }


### PR DESCRIPTION
Continued from #37 #42 #51 

`StreamingMessageParser.parse()` can't handle multipart message properly because AI SDK changes `message.id` when added new parts. (see also https://github.com/vercel/ai/issues/5318)

As workaround, this PR bypasses the problem of the parser by finding and not adding duplicate strings, and prevents the same sentence from being repeated when using the tool.

Also, it adds times to log messages for handy debug.