### PR TITLE
feat: reset prev parsed message

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -322,7 +322,7 @@ export const ChatImpl = memo(({ description, initialMessages, setInitialMessages
   }, [model, provider, searchParams]);
 
   const { enhancingPrompt, promptEnhanced, enhancePrompt, resetEnhancer } = usePromptEnhancer();
-  const { parsedMessages, parseMessages } = useMessageParser();
+  const { parsedMessages, parseMessages, resetParsedMessagesFrom } = useMessageParser();
 
   const TEXTAREA_MAX_HEIGHT = chatStarted ? 400 : 200;
 
@@ -350,8 +350,9 @@ export const ChatImpl = memo(({ description, initialMessages, setInitialMessages
     try {
       await commitChanges(message, (commitHash) => {
         workbenchStore.setReloadedMessages([...messages.map((m) => m.id), commitHash]);
-        setMessages((prev: Message[]) =>
-          prev.map((m: Message) => {
+
+        setMessages((prev: Message[]) => {
+          const newMessages = prev.map((m: Message) => {
             if (m.id === message.id) {
               return {
                 ...m,
@@ -360,8 +361,12 @@ export const ChatImpl = memo(({ description, initialMessages, setInitialMessages
             }
 
             return m;
-          }),
-        );
+          });
+
+          resetParsedMessagesFrom(newMessages.length - 1);
+
+          return newMessages;
+        });
       });
     } catch (e) {
       toast.error('The code commit has failed. You can download the code and restore it.');
@@ -827,7 +832,7 @@ export const ChatImpl = memo(({ description, initialMessages, setInitialMessages
         ignoreChangeEvent: true,
       });
       setMessages(newMessages);
-
+      resetParsedMessagesFrom(messageIndex);
       setTimeout(() => {
         reload();
       }, 1000);

--- a/app/lib/hooks/useMessageParser.ts
+++ b/app/lib/hooks/useMessageParser.ts
@@ -47,6 +47,20 @@ const messageParser = new StreamingMessageParser({
 export function useMessageParser() {
   const [parsedMessages, setParsedMessages] = useState<{ [key: number]: string }>({});
 
+  const resetParsedMessagesFrom = useCallback((fromIndex: number) => {
+    setParsedMessages((prevParsed: { [key: number]: string }) => {
+      const newParsedMessages = { ...prevParsed };
+
+      Object.keys(prevParsed).forEach((key: string) => {
+        if (Number(key) >= fromIndex) {
+          delete newParsedMessages[Number(key)];
+        }
+      });
+
+      return newParsedMessages;
+    });
+  }, []);
+
   const parseMessages = useCallback((messages: Message[], isLoading: boolean) => {
     let reset = false;
 
@@ -101,5 +115,5 @@ export function useMessageParser() {
     }
   }, []);
 
-  return { parsedMessages, parseMessages };
+  return { parsedMessages, parseMessages, resetParsedMessagesFrom };
 }

--- a/app/lib/persistenceGitbase/gitlabService.ts
+++ b/app/lib/persistenceGitbase/gitlabService.ts
@@ -20,7 +20,7 @@ export class GitlabService {
   gitlabToken: string;
   enabled: boolean;
 
-  constructor(env: Env, temporaryMode?: boolean) {
+  constructor(env: Env, temporaryMode: boolean = false) {
     this.gitlabUrl = env.GITLAB_URL || 'https://gitlab.verse8.io';
     this.gitlabToken = env.GITLAB_TOKEN;
     this.enabled = env.VITE_GITLAB_PERSISTENCE_ENABLED === 'true' && !temporaryMode;


### PR DESCRIPTION
Resolve the issue of existing content being duplicated when changing the message ID or retry message
