### PR TITLE
feat: enables V8 Auth on MCP client

### DIFF
--- a/app/components/@settings/tabs/features/FeaturesTab.tsx
+++ b/app/components/@settings/tabs/features/FeaturesTab.tsx
@@ -108,7 +108,8 @@ const FeatureSection = memo(
 
 // MCP SSE Server Management Component
 const McpSseServerManager = () => {
-  const { mcpSseServers, addMCPSSEServer, removeMCPSSEServer, toggleMCPSSEServer } = useSettings();
+  const { mcpSseServers, addMCPSSEServer, removeMCPSSEServer, toggleMCPSSEServer, toggleMCPSSEServerV8Auth } =
+    useSettings();
 
   const [newServer, setNewServer] = useState<{ name: string; url: string }>({
     name: '',
@@ -121,6 +122,7 @@ const McpSseServerManager = () => {
         name: newServer.name,
         url: newServer.url,
         enabled: true,
+        v8AuthIntegrated: false,
       };
 
       addMCPSSEServer(server);
@@ -221,7 +223,33 @@ const McpSseServerManager = () => {
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                <Switch checked={server.enabled} onCheckedChange={(checked) => handleToggleServer(index, checked)} />
+                <div className="flex items-center gap-1">
+                  <span className="text-xs text-bolt-elements-textSecondary mr-1">
+                    {server.enabled ? 'Enabled' : 'Disabled'}
+                  </span>
+                  <Switch checked={server.enabled} onCheckedChange={(checked) => handleToggleServer(index, checked)} />
+                </div>
+                <div className="flex items-center gap-1">
+                  <span
+                    className={classNames(
+                      'text-xs mr-1',
+                      server.enabled ? 'text-bolt-elements-textSecondary' : 'text-bolt-elements-textTertiary',
+                    )}
+                  >
+                    V8 Auth
+                  </span>
+                  <div
+                    className={classNames(
+                      'i-ph:lock w-4 h-4',
+                      server.enabled ? 'text-bolt-elements-textSecondary' : 'text-bolt-elements-textTertiary',
+                    )}
+                  />
+                  <Switch
+                    checked={server.v8AuthIntegrated}
+                    disabled={!server.enabled}
+                    onCheckedChange={(checked) => toggleMCPSSEServerV8Auth(index, checked)}
+                  />
+                </div>
                 <button
                   onClick={() => handleRemoveServer(index)}
                   className="p-1 rounded-full hover:bg-red-500/10 text-red-500"

--- a/app/components/ui/Switch.tsx
+++ b/app/components/ui/Switch.tsx
@@ -5,10 +5,11 @@ import { classNames } from '~/utils/classNames';
 interface SwitchProps {
   className?: string;
   checked?: boolean;
+  disabled?: boolean;
   onCheckedChange?: (event: boolean) => void;
 }
 
-export const Switch = memo(({ className, onCheckedChange, checked }: SwitchProps) => {
+export const Switch = memo(({ className, onCheckedChange, checked, disabled }: SwitchProps) => {
   return (
     <SwitchPrimitive.Root
       className={classNames(
@@ -20,6 +21,7 @@ export const Switch = memo(({ className, onCheckedChange, checked }: SwitchProps
         className,
       )}
       checked={checked}
+      disabled={disabled}
       onCheckedChange={(e) => onCheckedChange?.(e)}
     >
       <SwitchPrimitive.Thumb

--- a/app/lib/api/cookies.ts
+++ b/app/lib/api/cookies.ts
@@ -37,7 +37,12 @@ export function getProviderSettingsFromCookie(cookieHeader: string | null): Reco
 
 export function getMCPConfigFromCookie(cookieHeader: string | null): MCPConfig {
   const cookies = parseCookies(cookieHeader);
-  const servers: MCPServerConfig[] = cookies.mcpSseServers ? JSON.parse(cookies.mcpSseServers) : [];
+  const servers: MCPServerConfig[] = cookies.mcpSseServers
+    ? JSON.parse(cookies.mcpSseServers).map((server: MCPServerConfig) => ({
+        ...server,
+        v8AuthIntegrated: server.v8AuthIntegrated ?? false,
+      }))
+    : [];
 
   return {
     source: 'cookie',

--- a/app/lib/hooks/useSettings.ts
+++ b/app/lib/hooks/useSettings.ts
@@ -22,6 +22,7 @@ import {
   updateMCPSSEServer,
   removeMCPSSEServer,
   toggleMCPSSEServer,
+  toggleMCPSSEServerV8Auth,
   type MCPSSEServer,
   temporaryModeStore,
   updateTemporaryMode,
@@ -83,6 +84,7 @@ export interface UseSettingsReturn {
   updateMCPSSEServer: (index: number, server: MCPSSEServer) => void;
   removeMCPSSEServer: (index: number) => void;
   toggleMCPSSEServer: (index: number, enabled: boolean) => void;
+  toggleMCPSSEServerV8Auth: (index: number, v8AuthIntegrated: boolean) => void;
 }
 
 // Add interface to match ProviderSetting type
@@ -241,5 +243,6 @@ export function useSettings(): UseSettingsReturn {
     updateMCPSSEServer,
     removeMCPSSEServer,
     toggleMCPSSEServer,
+    toggleMCPSSEServerV8Auth,
   };
 }

--- a/app/lib/modules/mcp/config.ts
+++ b/app/lib/modules/mcp/config.ts
@@ -9,6 +9,7 @@ export interface MCPServerConfig {
   name: string;
   url: string;
   enabled: boolean;
+  v8AuthIntegrated: boolean;
 }
 
 export type MCPConfigSource = 'cookie' | 'env';

--- a/app/lib/stores/settings.ts
+++ b/app/lib/stores/settings.ts
@@ -34,6 +34,7 @@ export interface MCPSSEServer {
   name: string;
   url: string;
   enabled: boolean;
+  v8AuthIntegrated: boolean;
 }
 
 export const URL_CONFIGURABLE_PROVIDERS = ['Ollama', 'LMStudio', 'OpenAILike'];
@@ -409,5 +410,12 @@ export const toggleMCPSSEServer = (index: number, enabled: boolean) => {
   const servers = mcpSseServersStore.get();
   const updatedServers = [...servers];
   updatedServers[index] = { ...updatedServers[index], enabled };
+  updateMCPSSEServers(updatedServers);
+};
+
+export const toggleMCPSSEServerV8Auth = (index: number, v8AuthIntegrated: boolean) => {
+  const servers = mcpSseServersStore.get();
+  const updatedServers = [...servers];
+  updatedServers[index] = { ...updatedServers[index], v8AuthIntegrated };
   updateMCPSSEServers(updatedServers);
 };

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -15,7 +15,7 @@ import { searchVectorDB } from '~/lib/.server/llm/search-vectordb';
 import { searchResources } from '~/lib/.server/llm/search-resources';
 import { getMCPConfigFromCookie } from '~/lib/api/cookies';
 import { cleanupToolSet, createToolSet } from '~/lib/modules/mcp/toolset';
-import { withV8AuthUser, type ContextConsumeUserCredit } from '~/lib/verse8/middleware';
+import { withV8AuthUser, type ContextConsumeUserCredit, type ContextUser } from '~/lib/verse8/middleware';
 
 export const action = withV8AuthUser(chatAction, { checkCredit: true });
 
@@ -70,7 +70,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
 
   try {
     const mcpConfig = getMCPConfigFromCookie(cookieHeader);
-    const mcpToolset = await createToolSet(mcpConfig);
+    const mcpToolset = await createToolSet(mcpConfig, (context.user as ContextUser)?.accessToken);
     const mcpTools = mcpToolset.tools;
     logger.debug(`mcpConfig: ${JSON.stringify(mcpConfig)}`);
 

--- a/app/routes/api.llmcall.ts
+++ b/app/routes/api.llmcall.ts
@@ -9,7 +9,7 @@ import type { ModelInfo } from '~/lib/modules/llm/types';
 import { getApiKeysFromCookie, getProviderSettingsFromCookie, getMCPConfigFromCookie } from '~/lib/api/cookies';
 import { createScopedLogger } from '~/utils/logger';
 import { cleanupToolSet, createToolSet } from '~/lib/modules/mcp/toolset';
-import { withV8AuthUser, type ContextConsumeUserCredit } from '~/lib/verse8/middleware';
+import { withV8AuthUser, type ContextConsumeUserCredit, type ContextUser } from '~/lib/verse8/middleware';
 
 export const action = withV8AuthUser(llmCallAction, { checkCredit: true });
 
@@ -54,7 +54,7 @@ async function llmCallAction({ context, request }: ActionFunctionArgs) {
   const apiKeys = getApiKeysFromCookie(cookieHeader);
   const providerSettings = getProviderSettingsFromCookie(cookieHeader);
   const mcpConfig = getMCPConfigFromCookie(cookieHeader);
-  const mcpToolset = await createToolSet(mcpConfig);
+  const mcpToolset = await createToolSet(mcpConfig, (context.user as ContextUser)?.accessToken);
   const mcpTools = mcpToolset.tools;
 
   if (streamOutput) {

--- a/app/styles/diff-view.css
+++ b/app/styles/diff-view.css
@@ -69,4 +69,4 @@
 
 .diff-removed {
   @apply bg-red-500/20 border-l-4 border-red-500;
-} 
+}


### PR DESCRIPTION
See also: https://github.com/planetarium/mcp-agent8/issues/7

This PR adds `v8AuthIntegrated` flag to `MCPServerConfig`, and set v8 access token to header if MCP server has that flag.