### PR TITLE
fix: update wrangler.toml to care CloudFlare's cache error

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "agent8"
-compatibility_flags = ["nodejs_compat"]
-compatibility_date = "2024-09-23"
+compatibility_flags = ["nodejs_compat", "cache_option_enabled"]
+compatibility_date = "2024-11-11"
 pages_build_output_dir = "./build/client"
 send_metrics = false


### PR DESCRIPTION
See also: https://github.com/cloudflare/workerd/issues/698, https://developers.cloudflare.com/workers/configuration/compatibility-flags/#enable-cache-no-store-http-standard-api

This PR bumps `wrangler.toml` and turns on `cache_option_enabled`, to fix `The 'cache' field on 'RequestInitializerDict' is not implemented.` error.