### PR TITLE
feat: introduce shell related interfaces

### DIFF
--- a/app/lib/container/interfaces.ts
+++ b/app/lib/container/interfaces.ts
@@ -44,6 +44,7 @@ export interface FileSystem {
   readdir(path: string, options?: { withFileTypes?: boolean }): Promise<FileEntry[]>;
   rm(path: string, options?: { force?: boolean; recursive?: boolean }): Promise<void>;
   watch(pattern: string, options?: { persistent?: boolean }): FileSystemWatcher;
+  watchPaths(options: WatchPathsOptions, callback: (events: PathWatcherEvent[]) => void): void;
 }
 
 /**
@@ -107,9 +108,6 @@ export interface Container {
   on(event: 'error', listener: ErrorListener): Unsubscribe;
   mount(data: FileSystemTree): Promise<void>;
   spawn(command: string, args?: string[], options?: SpawnOptions): Promise<ContainerProcess>;
-  internal: {
-    watchPaths(options: WatchPathsOptions, callback: (events: PathWatcherEvent[]) => void): void;
-  };
 }
 
 /**

--- a/app/lib/container/interfaces.ts
+++ b/app/lib/container/interfaces.ts
@@ -2,6 +2,8 @@
  * File system related types and interfaces
  */
 
+import type { ITerminal } from '~/types/terminal';
+
 export type Unsubscribe = () => void;
 export type PortListener = (port: number, type: string, url: string) => void;
 export type ServerReadyListener = (port: number, url: string) => void;
@@ -70,6 +72,37 @@ export interface SpawnOptions {
 }
 
 /**
+ * Shell session interface for integrated shell functionality
+ */
+export interface ShellSession {
+  process: ContainerProcess;
+  input: WritableStreamDefaultWriter<string>;
+  output: ReadableStream<string>;
+  internalOutput?: ReadableStream<string>;
+  ready: Promise<void>;
+
+  executeCommand?(command: string): Promise<ExecutionResult>;
+  waitTillOscCode?(code: string): Promise<{ output: string; exitCode: number }>;
+}
+
+/**
+ * Shell options interface
+ */
+export interface ShellOptions {
+  args?: string[];
+  interactive?: boolean;
+  splitOutput?: boolean;
+}
+
+/**
+ * Shell execution result interface
+ */
+export interface ExecutionResult {
+  output: string;
+  exitCode: number;
+}
+
+/**
  * Path watcher event interface
  */
 export interface PathWatcherEvent {
@@ -108,6 +141,14 @@ export interface Container {
   on(event: 'error', listener: ErrorListener): Unsubscribe;
   mount(data: FileSystemTree): Promise<void>;
   spawn(command: string, args?: string[], options?: SpawnOptions): Promise<ContainerProcess>;
+
+  /**
+   * Spawn a shell process with enhanced functionality
+   * @param terminal Terminal interface to connect with the shell
+   * @param options Shell specific options
+   * @returns Shell session with standard and enhanced shell functionality
+   */
+  spawnShell(terminal: ITerminal, options?: ShellOptions): Promise<ShellSession>;
 }
 
 /**

--- a/app/lib/container/webcontainer-impl.ts
+++ b/app/lib/container/webcontainer-impl.ts
@@ -10,7 +10,13 @@ import type {
   PathWatcherEvent,
   WatchPathsOptions,
   SpawnOptions,
+  ShellSession,
+  ShellOptions,
+  ExecutionResult,
 } from './interfaces';
+import type { ITerminal } from '~/types/terminal';
+import { withResolvers } from '~/utils/promises';
+import { cleanTerminalOutput } from '~/utils/shell';
 
 /**
  * WebContainer file system implementation
@@ -88,6 +94,138 @@ export class WebContainerFactory implements ContainerFactory {
         },
         on(event: 'port' | 'server-ready' | 'preview-message' | 'error', listener: any) {
           return (container as any).on(event, listener);
+        },
+        spawnShell: async (terminal: ITerminal, options: ShellOptions = {}): Promise<ShellSession> => {
+          const args: string[] = options.args || [];
+
+          // Create process
+          const process = await container.spawn('/bin/jsh', ['--osc', ...args], {
+            terminal: {
+              cols: terminal.cols ?? 80,
+              rows: terminal.rows ?? 15,
+            },
+          });
+
+          const input = process.input.getWriter();
+          let output = process.output;
+          let internalOutput: ReadableStream<string> | undefined;
+
+          // Split output streams (BoltShell functionality)
+          if (options.splitOutput) {
+            const [internal, termOut] = process.output.tee();
+            output = termOut;
+            internalOutput = internal;
+          }
+
+          const jshReady = withResolvers<void>();
+
+          // Detect interactive mode
+          let isInteractive = false;
+          output.pipeTo(
+            new WritableStream({
+              write(data) {
+                if (!isInteractive && options.interactive !== false) {
+                  const [, osc] = data.match(/\x1b\]654;([^\x07]+)\x07/) || [];
+
+                  if (osc === 'interactive') {
+                    isInteractive = true;
+                    jshReady.resolve();
+                  }
+                }
+
+                terminal.write(data);
+              },
+            }),
+          );
+
+          // Handle terminal input
+          terminal.onData((data) => {
+            if (isInteractive) {
+              input.write(data);
+            }
+          });
+
+          // Advanced feature: Wait for OSC code and command execution
+          const waitTillOscCode = async (waitCode: string) => {
+            let fullOutput = '';
+            let exitCode = 0;
+
+            if (!internalOutput) {
+              return { output: fullOutput, exitCode };
+            }
+
+            const reader = internalOutput.getReader();
+
+            try {
+              while (true) {
+                const { value, done } = await reader.read();
+
+                if (done) {
+                  break;
+                }
+
+                const text = value || '';
+                fullOutput += text;
+
+                // Check for command completion signal and exit code
+                const [, osc, , , code] = text.match(/\x1b\]654;([^\x07=]+)=?((-?\d+):(\d+))?\x07/) || [];
+
+                if (osc === 'exit') {
+                  exitCode = parseInt(code, 10);
+                }
+
+                if (osc === waitCode) {
+                  break;
+                }
+              }
+            } finally {
+              reader.releaseLock();
+            }
+
+            return { output: fullOutput, exitCode };
+          };
+
+          // Implement command execution functionality
+          const executeCommand = async (command: string): Promise<ExecutionResult> => {
+            // Interrupt current execution
+            terminal.input('\x03');
+
+            // Wait for prompt
+            await waitTillOscCode('prompt');
+
+            // Execute new command
+            terminal.input(command.trim() + '\n');
+
+            // Wait for execution result
+            const { output, exitCode } = await waitTillOscCode('exit');
+
+            return {
+              output: cleanTerminalOutput(output),
+              exitCode,
+            };
+          };
+
+          // Construct session object
+          const session: ShellSession = {
+            process,
+            input,
+            output,
+            ready: jshReady.promise,
+          };
+
+          // Add enhanced features only if needed
+          if (internalOutput) {
+            session.internalOutput = internalOutput;
+            session.waitTillOscCode = waitTillOscCode;
+            session.executeCommand = executeCommand;
+          }
+
+          // Wait for interactive mode activation
+          if (options.interactive !== false) {
+            await jshReady.promise;
+          }
+
+          return session;
         },
       };
     } catch (error) {

--- a/app/lib/stores/files.ts
+++ b/app/lib/stores/files.ts
@@ -134,7 +134,7 @@ export class FilesStore {
   async #init() {
     const container = await this.#container;
 
-    container.internal.watchPaths(
+    container.fs.watchPaths(
       { include: [`${WORK_DIR}/**`], exclude: ['**/node_modules', '.git'], includeContent: true },
       bufferWatchEvents(100, this.#processEventBuffer.bind(this)),
     );


### PR DESCRIPTION
Continued from #71 

This PR extracts shell related interfaces from existing codes and abstract duplicated usages.
Also, it moves `watchPaths()` from `Container.internal` to `FileSystem` to fit its purpose.