### PR TITLE
feat: adjust mcp option to tim

### DIFF
--- a/app/lib/modules/mcp/toolset.ts
+++ b/app/lib/modules/mcp/toolset.ts
@@ -199,6 +199,7 @@ export async function createToolSet(config: MCPConfig, v8AuthToken?: string): Pr
                     // Emit progress event
                     progressEmitter.emit('progress', progress);
                   },
+                  resetTimeoutOnProgress: true,
                 },
               );
 


### PR DESCRIPTION
See also: https://github.com/modelcontextprotocol/typescript-sdk/issues/192

This PR adds `resetTimeoutOnProgress` to prevent MCP timeout while receiving `onProgress` from the server.