### PR TITLE
fix: remote container boot

### DIFF
--- a/app/components/workbench/Workbench.client.tsx
+++ b/app/components/workbench/Workbench.client.tsx
@@ -312,6 +312,7 @@ export const Workbench = memo(({ chatStarted, isStreaming, actionRunner }: Works
   renderLogger.trace('Workbench');
 
   const [fileHistory, setFileHistory] = useState<Record<string, FileHistory>>({});
+  const [terminalReady, setTerminalReady] = useState(false);
 
   // const modifiedFiles = Array.from(useStore(workbenchStore.unsavedFiles).keys());
 
@@ -355,6 +356,19 @@ export const Workbench = memo(({ chatStarted, isStreaming, actionRunner }: Works
   useEffect(() => {
     workbenchStore.setDocuments(files);
   }, [files]);
+
+  useEffect(() => {
+    if (chatStarted) {
+      const initializeTerminal = async () => {
+        const shell = workbenchStore.boltTerminal;
+
+        await shell.ready;
+        setTerminalReady(true);
+      };
+
+      initializeTerminal();
+    }
+  }, [chatStarted]);
 
   const onRun = useCallback(async () => {
     setSelectedView('code');
@@ -403,6 +417,22 @@ export const Workbench = memo(({ chatStarted, isStreaming, actionRunner }: Works
         variants={workbenchVariants}
         className="z-workbench"
       >
+        {showWorkbench && !terminalReady && (
+          <div className="fixed top-[calc(var(--header-height)+1.5rem)] bottom-6 w-[var(--workbench-inner-width)] mr-4 z-10 left-[var(--workbench-left)] transition-[left,width] duration-200 bolt-ease-cubic-bezier">
+            <div className="absolute inset-0 px-2 lg:px-6">
+              <div className="h-full flex flex-col bg-bolt-elements-background-depth-2 border border-bolt-elements-borderColor shadow-sm rounded-lg overflow-hidden">
+                <div className="absolute inset-0 z-50 bg-bolt-elements-background-depth-2 bg-opacity-75 flex items-center justify-center">
+                  <div className="p-4 rounded-lg bg-bolt-elements-background-depth-3 shadow-lg">
+                    <div className="animate-spin w-6 h-6 mb-2 mx-auto">
+                      <div className="i-ph:spinner" />
+                    </div>
+                    <div className="text-sm text-bolt-elements-textPrimary">Preparing Workbench...</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
         <div
           className={classNames(
             'fixed top-[calc(var(--header-height)+1.5rem)] bottom-6 w-[var(--workbench-inner-width)] mr-4 z-0 transition-[left,width] duration-200 bolt-ease-cubic-bezier',

--- a/app/lib/container/index.ts
+++ b/app/lib/container/index.ts
@@ -35,6 +35,7 @@ if (!import.meta.env.SSR) {
           coep: 'credentialless',
           workdirName: WORK_DIR_NAME,
           forwardPreviewErrors: true,
+          v8AccessToken: localStorage.getItem('v8AccessToken') || undefined,
         });
       })
       .then(async (containerInstance) => {

--- a/app/lib/container/interfaces.ts
+++ b/app/lib/container/interfaces.ts
@@ -125,6 +125,7 @@ export interface ContainerOptions {
   coep?: 'credentialless';
   workdirName?: string;
   forwardPreviewErrors?: boolean;
+  v8AccessToken?: string;
 }
 
 /**

--- a/app/lib/container/remote-container-impl.spec.ts
+++ b/app/lib/container/remote-container-impl.spec.ts
@@ -59,7 +59,7 @@ describe('RemoteContainer 통합 테스트', () => {
 
   beforeEach(async () => {
     // 실제 컨테이너 팩토리 생성 및 부팅
-    const factory = new RemoteContainerFactory(TEST_SERVER_URL);
+    const factory = new RemoteContainerFactory(TEST_SERVER_URL, 'fly-summer-log-9042');
     container = (await factory.boot({ workdirName: '/workspace' })) as RemoteContainer;
   });
 

--- a/app/lib/container/remote-container-impl.spec.ts
+++ b/app/lib/container/remote-container-impl.spec.ts
@@ -1,6 +1,6 @@
 import { WebSocket } from 'ws';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { RemoteContainer, RemoteContainerFactory } from '~/lib/container/remote-container-impl';
+import { RemoteContainer } from '~/lib/container/remote-container-impl';
 import type { FileSystemTree, PathWatcherEvent } from '~/lib/container/interfaces';
 import type { ITerminal } from '~/types/terminal';
 
@@ -10,7 +10,9 @@ global.WebSocket = WebSocket as any;
  * 실제 서버 연결을 위한 설정
  * 테스트 실행 시 실제 서버에 연결합니다.
  */
-const TEST_SERVER_URL = 'ws://agent8-container.fly.dev/'; // 테스트용 서버 URL 설정
+const TEST_SERVER_URL = 'wss://fly-summer-log-9042-08016e2f09d2d8.agent8.verse8.net/'; // 테스트용 서버 URL 설정
+const TEST_V8_ACCESS_TOKEN = '<v8-access-token>';
+const TEST_WORKDIR = '/workspace';
 
 /**
  * 실제 터미널 연결을 위한 터미널 목업
@@ -58,9 +60,7 @@ describe('RemoteContainer 통합 테스트', () => {
   let container: RemoteContainer;
 
   beforeEach(async () => {
-    // 실제 컨테이너 팩토리 생성 및 부팅
-    const factory = new RemoteContainerFactory(TEST_SERVER_URL, 'fly-summer-log-9042');
-    container = (await factory.boot({ workdirName: '/workspace' })) as RemoteContainer;
+    container = new RemoteContainer(TEST_SERVER_URL, TEST_WORKDIR, TEST_V8_ACCESS_TOKEN);
   });
 
   afterEach(() => {

--- a/app/lib/container/remote-container-impl.ts
+++ b/app/lib/container/remote-container-impl.ts
@@ -699,10 +699,10 @@ export class RemoteContainerFactory implements ContainerFactory {
   async boot(options: ContainerOptions): Promise<Container> {
     try {
       const workdir = options.workdirName || '/workspace';
-      const v8AccessToken = localStorage.getItem('v8AccessToken');
+      const v8AccessToken = options.v8AccessToken;
 
-      if (v8AccessToken === null) {
-        throw new Error('No V8 access token found');
+      if (!v8AccessToken) {
+        throw new Error('No V8 access token given');
       }
 
       const response = await fetch(`https://${this._serverUrl}/api/machine`, {

--- a/app/lib/container/remote-container-impl.ts
+++ b/app/lib/container/remote-container-impl.ts
@@ -535,6 +535,9 @@ export class RemoteContainer implements Container {
 
     // Use appropriate shell command
     const process = await this.spawn('/bin/zsh', ['--interactive', ...args], {
+      env: {
+        __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: '.agent8.verse8.net',
+      },
       terminal: {
         cols: terminal.cols ?? 80,
         rows: terminal.rows ?? 15,

--- a/app/lib/container/remote-container-impl.ts
+++ b/app/lib/container/remote-container-impl.ts
@@ -441,7 +441,7 @@ export class RemoteContainerFileSystem implements FileSystem {
 export class RemoteContainer implements Container {
   readonly fs: FileSystem;
   readonly workdir: string;
-  readonly machine_id?: string;
+  readonly machineId: string;
 
   private _connection: RemoteContainerConnection;
 
@@ -449,9 +449,7 @@ export class RemoteContainer implements Container {
     this._connection = new RemoteContainerConnection(serverUrl, token, machineId);
     this.fs = new RemoteContainerFileSystem(this._connection);
     this.workdir = workdir;
-    this.machine_id = '';
-
-    // Fetch machine_id if token is provided
+    this.machineId = machineId;
   }
 
   on<E extends keyof EventListenerMap>(event: E, listener: EventListenerMap[E]): Unsubscribe {

--- a/app/lib/container/remote-container-impl.ts
+++ b/app/lib/container/remote-container-impl.ts
@@ -28,6 +28,8 @@ import type {
 } from '~/lib/shared/agent8-container-protocol/src';
 import { v4 } from 'uuid';
 
+const ROUTER_DOMAIN = 'agent8.verse8.net';
+
 /**
  * Class to manage remote WebSocket connection and communication
  */
@@ -536,7 +538,7 @@ export class RemoteContainer implements Container {
     // Use appropriate shell command
     const process = await this.spawn('/bin/zsh', ['--interactive', ...args], {
       env: {
-        __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: '.agent8.verse8.net',
+        __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: `.${ROUTER_DOMAIN}`,
       },
       terminal: {
         cols: terminal.cols ?? 80,
@@ -723,7 +725,7 @@ export class RemoteContainerFactory implements ContainerFactory {
 
       // Create remote container instance
       const container = new RemoteContainer(
-        `wss://${this._appName}-${machineId}.agent8.verse8.net`,
+        `wss://${this._appName}-${machineId}.${ROUTER_DOMAIN}`,
         workdir,
         v8AccessToken,
       );

--- a/app/lib/container/webcontainer-impl.ts
+++ b/app/lib/container/webcontainer-impl.ts
@@ -78,7 +78,7 @@ export class WebContainerFactory implements ContainerFactory {
     try {
       const container = await WebContainer.boot(options);
       const rfactory = new RemoteContainerFactory('fly-summer-log-9042.fly.dev', 'fly-summer-log-9042');
-      const rcontainer = await rfactory.boot({ workdirName: container.workdir });
+      const rcontainer = await rfactory.boot({ workdirName: container.workdir, ...options });
 
       // Directly implement the Container interface instead of using an adapter
       return {

--- a/app/lib/container/webcontainer-impl.ts
+++ b/app/lib/container/webcontainer-impl.ts
@@ -77,7 +77,7 @@ export class WebContainerFactory implements ContainerFactory {
   async boot(options: ContainerOptions): Promise<Container> {
     try {
       const container = await WebContainer.boot(options);
-      const rfactory = new RemoteContainerFactory('agent8-container.fly.dev');
+      const rfactory = new RemoteContainerFactory('fly-summer-log-9042.fly.dev', 'fly-summer-log-9042');
       const rcontainer = await rfactory.boot({ workdirName: container.workdir });
 
       // Directly implement the Container interface instead of using an adapter


### PR DESCRIPTION
This PR organizes boot phase for `RemoteContainer` and adds splash screen while booting.

![image](https://github.com/user-attachments/assets/c8207fa4-0c0e-4897-8729-56b7f5c1573b)


Also, it changes proxy mechanism to reflect `fly replay` based router, for preview feature.