### PR TITLE
feat: introduce streamable HTTP for MCP client

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -29,7 +29,7 @@ import ProgressCompilation from './ProgressCompilation';
 import type { ProgressAnnotation } from '~/types/context';
 import type { ActionRunner } from '~/lib/runtime/action-runner';
 import { ImportProjectZip } from './ImportProjectZip';
-import McpSseServerManager from '~/components/chat/McpSseServerManager';
+import McpServerManager from '~/components/chat/McpServerManager';
 import { FaCheckSquare, FaSquare } from 'react-icons/fa';
 import { DEFAULT_TASK_BRANCH, repoStore } from '~/lib/stores/repo';
 import { useStore } from '@nanostores/react';
@@ -534,7 +534,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                 </div>
                 {progressAnnotations && <ProgressCompilation data={progressAnnotations} />}
 
-                <McpSseServerManager />
+                <McpServerManager />
 
                 <div
                   className={classNames(

--- a/app/components/chat/McpServerManager.tsx
+++ b/app/components/chat/McpServerManager.tsx
@@ -3,14 +3,13 @@ import { motion } from 'framer-motion';
 import { Switch } from '~/components/ui/Switch';
 import { toast } from 'react-toastify';
 import { useSettings } from '~/lib/hooks/useSettings';
-import type { MCPSSEServer } from '~/lib/stores/settings';
+import type { MCPServer } from '~/lib/stores/settings';
 import { SETTINGS_KEYS } from '~/lib/stores/settings';
 import { classNames } from '~/utils/classNames';
 
-// MCP SSE Server Manager Component
-const McpSseServerManager: React.FC = () => {
-  const { mcpSseServers, addMCPSSEServer, removeMCPSSEServer, toggleMCPSSEServer, toggleMCPSSEServerV8Auth } =
-    useSettings();
+// MCP Server Manager Component
+const McpServerManager: React.FC = () => {
+  const { mcpServers, addMCPServer, removeMCPServer, toggleMCPServer, toggleMCPServerV8Auth } = useSettings();
 
   const defaultServerNames = ['All-in-one', 'Image', 'Cinematic', 'Audio', 'Skybox'];
 
@@ -80,7 +79,7 @@ const McpSseServerManager: React.FC = () => {
 
   const handleAddServer = () => {
     if (newServer.name && newServer.url) {
-      const server: MCPSSEServer = {
+      const server: MCPServer = {
         name: newServer.name,
         url: newServer.url,
         enabled: true,
@@ -88,7 +87,7 @@ const McpSseServerManager: React.FC = () => {
         description: newServer.description,
       };
 
-      addMCPSSEServer(server);
+      addMCPServer(server);
       toast.success(`${newServer.name} tool added`, { autoClose: 1500 });
 
       // 쿠키가 설정되었는지 확인
@@ -103,7 +102,7 @@ const McpSseServerManager: React.FC = () => {
           );
 
           console.log('Current cookies:', cookies);
-          console.log(`MCP settings cookie present:`, cookies[SETTINGS_KEYS.MCP_SSE_SERVERS] !== undefined);
+          console.log(`MCP settings cookie present:`, cookies[SETTINGS_KEYS.MCP_SERVERS] !== undefined);
         } catch (error) {
           console.error('Error checking cookies:', error);
         }
@@ -115,18 +114,18 @@ const McpSseServerManager: React.FC = () => {
   };
 
   const handleRemoveServer = (index: number) => {
-    removeMCPSSEServer(index);
+    removeMCPServer(index);
 
     toast.success('tool removed', { autoClose: 1500 });
   };
 
   const handleToggleServer = (index: number, enabled: boolean) => {
-    toggleMCPSSEServer(index, enabled);
+    toggleMCPServer(index, enabled);
 
     if (enabled) {
-      toggleMCPSSEServerV8Auth(index, true);
+      toggleMCPServerV8Auth(index, true);
     } else {
-      toggleMCPSSEServerV8Auth(index, false);
+      toggleMCPServerV8Auth(index, false);
     }
   };
 
@@ -153,9 +152,9 @@ const McpSseServerManager: React.FC = () => {
             </div>
           </div>
 
-          {mcpSseServers.length > 0 ? (
+          {mcpServers.length > 0 ? (
             <div className="grid grid-cols-1 gap-2">
-              {mcpSseServers
+              {mcpServers
                 .map((server, index) => ({ server, index }))
                 .filter((item) => item.server.name !== 'All-in-one')
                 .map(({ server, index }) => (
@@ -347,7 +346,7 @@ const McpSseServerManager: React.FC = () => {
             </div>
           ) : (
             <div className="text-center p-4 text-bolt-elements-textSecondary text-sm">
-              No MCP SSE servers registered. Add a new server to get started.
+              No MCP servers registered. Add a new server to get started.
             </div>
           )}
 
@@ -466,7 +465,7 @@ const McpSseServerManager: React.FC = () => {
         </motion.div>
       )}
       <div className="flex items-center gap-2 mb-2 flex-wrap">
-        {mcpSseServers
+        {mcpServers
           .map((server, index) => ({ server, index }))
           .filter((item) => item.server.enabled && item.server.name !== 'All-in-one')
           .map(({ server, index }) => (
@@ -498,4 +497,4 @@ const McpSseServerManager: React.FC = () => {
   );
 };
 
-export default McpSseServerManager;
+export default McpServerManager;

--- a/app/lib/api/cookies.ts
+++ b/app/lib/api/cookies.ts
@@ -37,6 +37,8 @@ export function getProviderSettingsFromCookie(cookieHeader: string | null): Reco
 
 export function getMCPConfigFromCookie(cookieHeader: string | null): MCPConfig {
   const cookies = parseCookies(cookieHeader);
+
+  // for backward compatibility, use cookies.mcpSseServers.
   const servers: MCPServerConfig[] = cookies.mcpSseServers
     ? JSON.parse(cookies.mcpSseServers).map((server: MCPServerConfig) => ({
         ...server,

--- a/app/lib/hooks/useSettings.ts
+++ b/app/lib/hooks/useSettings.ts
@@ -16,15 +16,15 @@ import {
   updateContextOptimization,
   updateEventLogs,
   updatePromptId,
-  mcpSseServersStore,
-  updateMCPSSEServers,
-  addMCPSSEServer,
-  updateMCPSSEServer,
-  removeMCPSSEServer,
-  toggleMCPSSEServer,
-  toggleMCPSSEServerV8Auth,
-  resetMCPSSEServers,
-  type MCPSSEServer,
+  mcpServersStore,
+  updateMCPServers,
+  addMCPServer,
+  updateMCPServer,
+  removeMCPServer,
+  toggleMCPServer,
+  toggleMCPServerV8Auth,
+  resetMCPServers,
+  type MCPServer,
   temporaryModeStore,
   updateTemporaryMode,
   updateAgent8Deploy,
@@ -82,15 +82,15 @@ export interface UseSettingsReturn {
   updateTabConfiguration: (config: TabVisibilityConfig) => void;
   resetTabConfiguration: () => void;
 
-  // MCP SSE server settings
-  mcpSseServers: MCPSSEServer[];
-  updateMCPSSEServers: (servers: MCPSSEServer[]) => void;
-  addMCPSSEServer: (server: MCPSSEServer) => void;
-  updateMCPSSEServer: (index: number, server: MCPSSEServer) => void;
-  removeMCPSSEServer: (index: number) => void;
-  toggleMCPSSEServer: (index: number, enabled: boolean) => void;
-  toggleMCPSSEServerV8Auth: (index: number, v8AuthIntegrated: boolean) => void;
-  resetMCPSSEServers: () => MCPSSEServer[];
+  // MCP server settings
+  mcpServers: MCPServer[];
+  updateMCPServers: (servers: MCPServer[]) => void;
+  addMCPServer: (server: MCPServer) => void;
+  updateMCPServer: (index: number, server: MCPServer) => void;
+  removeMCPServer: (index: number) => void;
+  toggleMCPServer: (index: number, enabled: boolean) => void;
+  toggleMCPServerV8Auth: (index: number, v8AuthIntegrated: boolean) => void;
+  resetMCPServers: () => MCPServer[];
 }
 
 // Add interface to match ProviderSetting type
@@ -108,7 +108,7 @@ export function useSettings(): UseSettingsReturn {
   const [activeProviders, setActiveProviders] = useState<ProviderInfo[]>([]);
   const contextOptimizationEnabled = useStore(enableContextOptimizationStore);
   const tabConfiguration = useStore(tabConfigurationStore);
-  const mcpSseServers = useStore(mcpSseServersStore);
+  const mcpServers = useStore(mcpServersStore);
   const temporaryMode = useStore(temporaryModeStore);
   const agent8Deploy = useStore(agent8DeployStore);
   const [settings, setSettings] = useState<Settings>(() => {
@@ -251,13 +251,13 @@ export function useSettings(): UseSettingsReturn {
     tabConfiguration,
     updateTabConfiguration: updateTabConfig,
     resetTabConfiguration: resetTabConfig,
-    mcpSseServers,
-    updateMCPSSEServers,
-    addMCPSSEServer,
-    updateMCPSSEServer,
-    removeMCPSSEServer,
-    toggleMCPSSEServer,
-    toggleMCPSSEServerV8Auth,
-    resetMCPSSEServers,
+    mcpServers,
+    updateMCPServers,
+    addMCPServer,
+    updateMCPServer,
+    removeMCPServer,
+    toggleMCPServer,
+    toggleMCPServerV8Auth,
+    resetMCPServers,
   };
 }

--- a/app/lib/stores/settings.ts
+++ b/app/lib/stores/settings.ts
@@ -29,8 +29,8 @@ export interface Shortcuts {
   toggleTerminal: Shortcut;
 }
 
-// MCP SSE server settings interface
-export interface MCPSSEServer {
+// MCP server settings interface
+export interface MCPServer {
   name: string;
   url: string;
   enabled: boolean;
@@ -142,14 +142,14 @@ export const SETTINGS_KEYS = {
   EVENT_LOGS: 'isEventLogsEnabled',
   PROMPT_ID: 'promptId',
   DEVELOPER_MODE: 'isDeveloperMode',
-  MCP_SSE_SERVERS: 'mcpSseServers',
+  MCP_SERVERS: 'mcpSseServers', // for backward compatibility
 } as const;
 
 /**
  * Helper function to get default MCP server configuration
  */
-const getDefaultMCPServers = (): MCPSSEServer[] => {
-  let defaultServers: MCPSSEServer[] = [];
+const getDefaultMCPServers = (): MCPServer[] => {
+  let defaultServers: MCPServer[] = [];
 
   if (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_MCP_SERVER_CONFIG) {
     defaultServers = JSON.parse(import.meta.env.VITE_MCP_SERVER_CONFIG);
@@ -200,22 +200,22 @@ const getDefaultMCPServers = (): MCPSSEServer[] => {
   return defaultServers;
 };
 
-// Get initial MCP SSE server settings from localStorage
-const getInitialMCPSSEServers = (): MCPSSEServer[] => {
+// Get initial MCP server settings from localStorage
+const getInitialMCPServers = (): MCPServer[] => {
   if (!isBrowser) {
     return [];
   }
 
   try {
-    const stored = localStorage.getItem(SETTINGS_KEYS.MCP_SSE_SERVERS);
+    const stored = localStorage.getItem(SETTINGS_KEYS.MCP_SERVERS);
     const defaultServers = getDefaultMCPServers();
 
     if (!stored || stored === '[]' || stored === '""') {
       // No stored servers, use defaults
-      localStorage.setItem(SETTINGS_KEYS.MCP_SSE_SERVERS, JSON.stringify(defaultServers));
+      localStorage.setItem(SETTINGS_KEYS.MCP_SERVERS, JSON.stringify(defaultServers));
 
       if (typeof Cookies !== 'undefined') {
-        Cookies.set(SETTINGS_KEYS.MCP_SSE_SERVERS, JSON.stringify(defaultServers), {
+        Cookies.set(SETTINGS_KEYS.MCP_SERVERS, JSON.stringify(defaultServers), {
           expires: 365,
           path: '/',
           sameSite: 'lax',
@@ -229,11 +229,10 @@ const getInitialMCPSSEServers = (): MCPSSEServer[] => {
     const storedServers = JSON.parse(stored);
 
     // Combine default servers with stored servers, using URL as unique identifier
-    const storedServerUrls = storedServers.map((server: MCPSSEServer) => server.url);
     const resultServers = [...defaultServers];
 
     // Add stored servers that aren't in default list
-    storedServers.forEach((storedServer: MCPSSEServer) => {
+    storedServers.forEach((storedServer: MCPServer) => {
       const existingIndex = resultServers.findIndex((server) => server.url === storedServer.url);
 
       if (existingIndex >= 0) {
@@ -251,10 +250,10 @@ const getInitialMCPSSEServers = (): MCPSSEServer[] => {
 
     if (resultJson !== storedJson) {
       // Update localStorage and cookies with combined result
-      localStorage.setItem(SETTINGS_KEYS.MCP_SSE_SERVERS, resultJson);
+      localStorage.setItem(SETTINGS_KEYS.MCP_SERVERS, resultJson);
 
       if (typeof Cookies !== 'undefined') {
-        Cookies.set(SETTINGS_KEYS.MCP_SSE_SERVERS, resultJson, {
+        Cookies.set(SETTINGS_KEYS.MCP_SERVERS, resultJson, {
           expires: 365,
           path: '/',
           sameSite: 'lax',
@@ -264,7 +263,7 @@ const getInitialMCPSSEServers = (): MCPSSEServer[] => {
 
     return resultServers;
   } catch (error) {
-    console.error('Failed to parse MCP SSE server settings:', error);
+    console.error('Failed to parse MCP server settings:', error);
     return getDefaultMCPServers(); // Return defaults on error
   }
 };
@@ -311,7 +310,7 @@ export const temporaryModeStore = atom<boolean>(initialSettings.temporaryMode);
 export const agent8DeployStore = atom<boolean>(initialSettings.agent8Deploy);
 export const isEventLogsEnabled = atom<boolean>(initialSettings.eventLogs);
 export const promptStore = atom<string>(initialSettings.promptId);
-export const mcpSseServersStore = atom<MCPSSEServer[]>(getInitialMCPSSEServers());
+export const mcpServersStore = atom<MCPServer[]>(getInitialMCPServers());
 
 // Helper functions to update settings with persistence
 export const updateLatestBranch = (enabled: boolean) => {
@@ -481,64 +480,64 @@ export const useSettingsStore = create<SettingsStore>((set) => ({
   },
 }));
 
-// MCP SSE Servers management functions
-export const updateMCPSSEServers = (servers: MCPSSEServer[]) => {
-  mcpSseServersStore.set(servers);
-  localStorage.setItem(SETTINGS_KEYS.MCP_SSE_SERVERS, JSON.stringify(servers));
+// MCP Servers management functions
+export const updateMCPServers = (servers: MCPServer[]) => {
+  mcpServersStore.set(servers);
+  localStorage.setItem(SETTINGS_KEYS.MCP_SERVERS, JSON.stringify(servers));
 
   // Also save to cookie for API routes
   try {
     // Use the same key name as localStorage for consistency
-    Cookies.set(SETTINGS_KEYS.MCP_SSE_SERVERS, JSON.stringify(servers), {
+    Cookies.set(SETTINGS_KEYS.MCP_SERVERS, JSON.stringify(servers), {
       expires: 365, // 1년간 유효
       path: '/',
       sameSite: 'lax',
     });
-    console.log('MCP SSE servers saved to cookies:', servers);
+    console.log('MCP servers saved to cookies:', servers);
   } catch (e) {
-    console.error('Failed to set mcpSseServers cookie:', e);
+    console.error('Failed to set mcpServers cookie:', e);
   }
 };
 
-export const resetMCPSSEServers = () => {
+export const resetMCPServers = () => {
   // Get default server configuration
   const defaultServers = getDefaultMCPServers();
 
   // Update store and cookies
-  updateMCPSSEServers(defaultServers);
+  updateMCPServers(defaultServers);
 
   return defaultServers;
 };
 
-export const addMCPSSEServer = (server: MCPSSEServer) => {
-  const servers = mcpSseServersStore.get();
+export const addMCPServer = (server: MCPServer) => {
+  const servers = mcpServersStore.get();
   const updatedServers = [...servers, server];
-  updateMCPSSEServers(updatedServers);
+  updateMCPServers(updatedServers);
 };
 
-export const updateMCPSSEServer = (index: number, server: MCPSSEServer) => {
-  const servers = mcpSseServersStore.get();
+export const updateMCPServer = (index: number, server: MCPServer) => {
+  const servers = mcpServersStore.get();
   const updatedServers = [...servers];
   updatedServers[index] = server;
-  updateMCPSSEServers(updatedServers);
+  updateMCPServers(updatedServers);
 };
 
-export const removeMCPSSEServer = (index: number) => {
-  const servers = mcpSseServersStore.get();
+export const removeMCPServer = (index: number) => {
+  const servers = mcpServersStore.get();
   const updatedServers = servers.filter((_, i) => i !== index);
-  updateMCPSSEServers(updatedServers);
+  updateMCPServers(updatedServers);
 };
 
-export const toggleMCPSSEServer = (index: number, enabled: boolean) => {
-  const servers = mcpSseServersStore.get();
+export const toggleMCPServer = (index: number, enabled: boolean) => {
+  const servers = mcpServersStore.get();
   const updatedServers = [...servers];
   updatedServers[index] = { ...updatedServers[index], enabled };
-  updateMCPSSEServers(updatedServers);
+  updateMCPServers(updatedServers);
 };
 
-export const toggleMCPSSEServerV8Auth = (index: number, v8AuthIntegrated: boolean) => {
-  const servers = mcpSseServersStore.get();
+export const toggleMCPServerV8Auth = (index: number, v8AuthIntegrated: boolean) => {
+  const servers = mcpServersStore.get();
   const updatedServers = [...servers];
   updatedServers[index] = { ...updatedServers[index], v8AuthIntegrated };
-  updateMCPSSEServers(updatedServers);
+  updateMCPServers(updatedServers);
 };

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@headlessui/react": "^2.2.0",
     "@iconify-json/svg-spinners": "^1.2.1",
     "@lezer/highlight": "^1.2.1",
-    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@modelcontextprotocol/sdk": "^1.11.1",
     "@nanostores/react": "^0.7.3",
     "@octokit/rest": "^21.0.2",
     "@octokit/types": "^13.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       '@modelcontextprotocol/sdk':
-        specifier: ^1.9.0
-        version: 1.9.0
+        specifier: ^1.11.1
+        version: 1.11.1
       '@nanostores/react':
         specifier: ^0.7.3
         version: 0.7.3(nanostores@0.10.3)(react@18.3.1)
@@ -2103,8 +2103,8 @@ packages:
   '@mdx-js/mdx@2.3.0':
     resolution: {integrity: sha512-jLuwRlz8DQfQNiUCJR50Y09CGPq3fLtmtUQfVrj79E0JWu3dvsVcxVIcfhR5h0iXu+/z++zDrYeiJqifRynJkA==}
 
-  '@modelcontextprotocol/sdk@1.9.0':
-    resolution: {integrity: sha512-Jq2EUCQpe0iyO5FGpzVYDNFR6oR53AIrwph9yWl7uSc7IWUMsrmpmSaTGra5hQNunXpM+9oit85p924jWuHzUA==}
+  '@modelcontextprotocol/sdk@1.11.1':
+    resolution: {integrity: sha512-9LfmxKTb1v+vUS1/emSk1f5ePmTLkb9Le9AxOB5T0XM59EUumwcS45z05h7aiZx3GI0Bl7mjb3FMEglYj+acuQ==}
     engines: {node: '>=18'}
 
   '@monogrid/gainmap-js@3.1.0':
@@ -11688,7 +11688,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.9.0':
+  '@modelcontextprotocol/sdk@1.11.1':
     dependencies:
       content-type: 1.0.5
       cors: 2.8.5


### PR DESCRIPTION
Related to: https://github.com/planetarium/mcp-agent8/pull/17

As title said, This PR introduces Streamable-HTTP transport for MCP client, to stabilize connectivity.  additional work may be required to ensure connection stability, we will try to work based on this Streamable-HTTP due to SSE transport deprecation.

Also, it changes terms "MCP SSE Server" to "MCP Server" in identifier and messages, to help further readers.