### PR TITLE
feat: diverse MCP settings by changing setting keys

### DIFF
--- a/app/lib/api/cookies.ts
+++ b/app/lib/api/cookies.ts
@@ -38,9 +38,8 @@ export function getProviderSettingsFromCookie(cookieHeader: string | null): Reco
 export function getMCPConfigFromCookie(cookieHeader: string | null): MCPConfig {
   const cookies = parseCookies(cookieHeader);
 
-  // for backward compatibility, use cookies.mcpSseServers.
-  const servers: MCPServerConfig[] = cookies.mcpSseServers
-    ? JSON.parse(cookies.mcpSseServers).map((server: MCPServerConfig) => ({
+  const servers: MCPServerConfig[] = cookies.mcpServers
+    ? JSON.parse(cookies.mcpServers).map((server: MCPServerConfig) => ({
         ...server,
         v8AuthIntegrated: server.v8AuthIntegrated ?? false,
       }))

--- a/app/lib/stores/settings.ts
+++ b/app/lib/stores/settings.ts
@@ -142,7 +142,7 @@ export const SETTINGS_KEYS = {
   EVENT_LOGS: 'isEventLogsEnabled',
   PROMPT_ID: 'promptId',
   DEVELOPER_MODE: 'isDeveloperMode',
-  MCP_SERVERS: 'mcpSseServers', // for backward compatibility
+  MCP_SERVERS: 'mcpServers',
 } as const;
 
 /**
@@ -157,14 +157,14 @@ const getDefaultMCPServers = (): MCPServer[] => {
     defaultServers = [
       {
         name: 'All-in-one',
-        url: 'https://mcp.verse8.io/sse',
+        url: 'https://mcp.verse8.io/mcp',
         enabled: false,
         v8AuthIntegrated: false,
         description: 'All-in-one server that integrates all MCP tools.',
       },
       {
         name: 'Image',
-        url: 'https://mcp-image.verse8.io/sse',
+        url: 'https://mcp-image.verse8.io/mcp',
         enabled: false,
         v8AuthIntegrated: false,
         description:
@@ -172,7 +172,7 @@ const getDefaultMCPServers = (): MCPServer[] => {
       },
       {
         name: 'Cinematic',
-        url: 'https://mcp-cinematic.verse8.io/sse',
+        url: 'https://mcp-cinematic.verse8.io/mcp',
         enabled: false,
         v8AuthIntegrated: false,
         description:
@@ -180,7 +180,7 @@ const getDefaultMCPServers = (): MCPServer[] => {
       },
       {
         name: 'Audio',
-        url: 'https://mcp-audio.verse8.io/sse',
+        url: 'https://mcp-audio.verse8.io/mcp',
         enabled: false,
         v8AuthIntegrated: false,
         description:
@@ -188,7 +188,7 @@ const getDefaultMCPServers = (): MCPServer[] => {
       },
       {
         name: 'Skybox',
-        url: 'https://mcp-skybox.verse8.io/sse',
+        url: 'https://mcp-skybox.verse8.io/mcp',
         enabled: false,
         v8AuthIntegrated: false,
         description:


### PR DESCRIPTION
Continue from #136 

Note) This PR should be merged AFTER setting MCP servers to support streamable-http.

It changes URLs for the default MCP server, to connect with Streamable HTTP instead of SSE.
Also it changes setting key value due to migration.