### PR TITLE
fix: stabilize remote container

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -54,9 +54,6 @@ function AccessControlledChat() {
           v8UserStore.set({ loading: false, user: userInfo });
 
           setIsActivated(userInfo.isActivated);
-
-          // we don't await here because we want to wait in the workbench
-          initializeContainer(accessToken);
         } catch (error) {
           console.error('Failed to verify token:', error);
           setIsActivated(false);


### PR DESCRIPTION
This PR contains three changes

1. `RemoteContainerFactory` now causes page reload when given v8 access token isn't valid.
2. `initializeContainer()` is called only after the 'INIT' message is called if `VITE_ACCESS_CONTROL_ENABLED` is set.
3. `RemoteContainer` will attempt to reconnect to the target container up to three times.