### PR TITLE
fix: handle preview Ethereum error

### DIFF
--- a/app/components/chat/ChatAlert.tsx
+++ b/app/components/chat/ChatAlert.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import { useEffect } from 'react';
+import { shouldIgnorePreviewError } from '~/utils/previewErrorFilters';
 import type { ActionAlert } from '~/types/actions';
 import { classNames } from '~/utils/classNames';
 
@@ -14,6 +15,17 @@ export default function ChatAlert({ autoFixChance, alert, clearAlert, postMessag
   const { description, content, source } = alert;
 
   const isPreview = source === 'preview';
+  const ignore = isPreview && shouldIgnorePreviewError(description);
+
+  useEffect(() => {
+    if (ignore) {
+      clearAlert();
+    }
+  }, [ignore, clearAlert]);
+
+  if (ignore) {
+    return null;
+  }
   const title = isPreview ? 'Preview Error' : 'Terminal Error';
   const message = isPreview
     ? 'We encountered an error while running the preview. Would you like Bolt to analyze and help resolve this issue?'

--- a/app/components/workbench/Preview.tsx
+++ b/app/components/workbench/Preview.tsx
@@ -207,6 +207,7 @@ export const Preview = memo(() => {
     const handleMessage = async (event: MessageEvent) => {
       if (event.data?.type === 'iframe-error') {
         const { error } = event.data;
+
         const { workbenchStore } = await import('~/lib/stores/workbench');
 
         let title = 'Error in Preview';

--- a/app/utils/previewErrorFilters.ts
+++ b/app/utils/previewErrorFilters.ts
@@ -1,0 +1,10 @@
+export const IGNORED_PREVIEW_ERROR_PATTERNS: RegExp[] = [
+  /Cannot redefine property: ethereum/,
+];
+
+export function shouldIgnorePreviewError(message?: string): boolean {
+  if (!message) {
+    return false;
+  }
+  return IGNORED_PREVIEW_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+}


### PR DESCRIPTION
## Summary
- ignore a known benign preview error
- centralize preview error ignores in a util

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/...)*