### PR TITLE
Add error message pattern for terminal output scan

### DIFF
--- a/app/components/workbench/terminal/Terminal.tsx
+++ b/app/components/workbench/terminal/Terminal.tsx
@@ -54,6 +54,9 @@ export const Terminal = memo(
             /failed to load module/i,
             /error resolving import/i,
             /failed to resolve import/i,
+            /\[ERROR\]/i,
+            /Build failed with \d+ errors/i,
+            /ELIFECYCLE.*Command failed with exit code/i,
           ];
 
           // Get the entire terminal buffer


### PR DESCRIPTION
Continued from #145, #147 

This PR adds error pattern for terminal error detecting.