### PR TITLE
feat: ensure user projects use latest packages with pnpm update

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -282,9 +282,9 @@ async function runAndPreview(message: Message) {
     await workbenchStore.setupDeployConfig(shell);
 
     if (localStorage.getItem(SETTINGS_KEYS.AGENT8_DEPLOY) === 'false') {
-      shell.executeCommand(Date.now().toString(), 'pnpm install && pnpm run dev');
+      shell.executeCommand(Date.now().toString(), 'pnpm update && pnpm run dev');
     } else {
-      shell.executeCommand(Date.now().toString(), 'pnpm install && npx -y @agent8/deploy --preview && pnpm run dev');
+      shell.executeCommand(Date.now().toString(), 'pnpm update && npx -y @agent8/deploy --preview && pnpm run dev');
     }
 
     break;

--- a/app/components/workbench/Workbench.client.tsx
+++ b/app/components/workbench/Workbench.client.tsx
@@ -380,11 +380,11 @@ export const Workbench = memo(({ chatStarted, isStreaming, actionRunner }: Works
     await shell.ready;
 
     if (localStorage.getItem(SETTINGS_KEYS.AGENT8_DEPLOY) === 'false') {
-      await shell.executeCommand(Date.now().toString(), 'pnpm install && pnpm run dev');
+      await shell.executeCommand(Date.now().toString(), 'pnpm update && pnpm run dev');
     } else {
       await shell.executeCommand(
         Date.now().toString(),
-        'pnpm install && npx -y @agent8/deploy --preview && pnpm run dev',
+        'pnpm update && npx -y @agent8/deploy --preview && pnpm run dev',
       );
     }
   }, []);

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -639,7 +639,7 @@ export class WorkbenchStore {
 
     try {
       // Install dependencies
-      await this.#runShellCommand(shell, 'pnpm install');
+      await this.#runShellCommand(shell, 'pnpm update');
 
       if (localStorage.getItem(SETTINGS_KEYS.AGENT8_DEPLOY) === 'false') {
         toast.error('Agent8 deploy is disabled. Please enable it in the settings.');


### PR DESCRIPTION
- Fixes an issue where cached `node_modules` in the container image prevented packages from upgrading to the latest versions.
- While the ideal solution is to rebuild the image frequently, creating a scheduled job would add maintenance overhead.
- As a straightforward workaround, this PR switches from `pnpm install` to `pnpm update`
- The change adds only 5~10 seconds to the build time.