### PR TITLE
fix: skip Ask Agent8 for chrome extension errors

### DIFF
--- a/app/utils/previewErrorFilters.ts
+++ b/app/utils/previewErrorFilters.ts
@@ -1,4 +1,7 @@
-export const IGNORED_PREVIEW_ERROR_PATTERNS: RegExp[] = [/Cannot redefine property: ethereum/];
+export const IGNORED_PREVIEW_ERROR_PATTERNS: RegExp[] = [
+  /Cannot redefine property: ethereum/,
+  /chrome-extension:\/\//,
+];
 
 export function shouldIgnorePreviewError(message?: string): boolean {
   if (!message) {


### PR DESCRIPTION
## Summary
- ignore preview errors that contain `chrome-extension://` so Ask Agent8 doesn't show