### PR TITLE
feat: Add project ownership verification to task-branches API

### DIFF
--- a/app/routes/api.gitlab.task-branches.ts
+++ b/app/routes/api.gitlab.task-branches.ts
@@ -42,6 +42,7 @@ async function branchesLoader({ context, request }: ActionFunctionArgs) {
  */
 async function branchesAction({ context, request }: ActionFunctionArgs) {
   const env = { ...context.cloudflare.env, ...process.env } as Env;
+  const user = context?.user as { email: string; isActivated: boolean };
 
   // Get request body as JSON
   const requestData = (await request.json()) as {
@@ -61,6 +62,13 @@ async function branchesAction({ context, request }: ActionFunctionArgs) {
   const gitlabService = new GitlabService(env);
 
   try {
+    // Verify the user owns this specific project (not just a project with same name)
+    const isOwner = await gitlabService.isProjectOwner(user.email, projectPath);
+
+    if (!isOwner) {
+      return json({ success: false, message: 'You do not have permission to access this project' }, { status: 403 });
+    }
+
     if (action === 'merge') {
       const { from, to = 'develop' } = requestData;
 


### PR DESCRIPTION
Add project ownership verification to prevent unauthorized access to other users' task branches. This PR adds user authentication check and uses isProjectOwner method to verify project ownership, returning 403 error for unauthorized access attempts.