### PR TITLE
fix: ensure workdir before @agent8/deploy

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -291,6 +291,9 @@ async function runAndPreview(message: Message) {
 
     await workbenchStore.setupDeployConfig(shell);
 
+    const container = await workbenchStore.container;
+    await shell.executeCommand(Date.now().toString(), `cd ${container.workdir}`);
+
     if (localStorage.getItem(SETTINGS_KEYS.AGENT8_DEPLOY) === 'false') {
       shell.executeCommand(Date.now().toString(), 'pnpm update && pnpm run dev');
     } else {

--- a/app/components/workbench/Workbench.client.tsx
+++ b/app/components/workbench/Workbench.client.tsx
@@ -379,6 +379,9 @@ export const Workbench = memo(({ chatStarted, isStreaming, actionRunner }: Works
 
     await shell.ready;
 
+    const container = await workbenchStore.container;
+    await shell.executeCommand(Date.now().toString(), `cd ${container.workdir}`);
+
     if (localStorage.getItem(SETTINGS_KEYS.AGENT8_DEPLOY) === 'false') {
       await shell.executeCommand(Date.now().toString(), 'pnpm update && pnpm run dev');
     } else {

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -815,6 +815,9 @@ export class WorkbenchStore {
       const { verseId } = await this.setupDeployConfig(shell);
       await this.commitModifiedFiles();
 
+      const container = await this.container;
+      await shell.executeCommand(Date.now().toString(), `cd ${container.workdir}`);
+
       // Build project
       const buildResult = await this.#runShellCommand(shell, 'pnpm run build');
 


### PR DESCRIPTION
Closes: #236 

This PR adds `cd <workdir>` to prevent `.env` file lookup failing on `@agent8/deploy`.