### PR TITLE
fix: skipping `pnpm run build` when deploy

### DIFF
--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -816,7 +816,7 @@ export class WorkbenchStore {
       await this.commitModifiedFiles();
 
       const container = await this.container;
-      await shell.executeCommand(Date.now().toString(), `cd ${container.workdir}`);
+      await this.#runShellCommand(shell, `cd ${container.workdir}`);
 
       // Build project
       const buildResult = await this.#runShellCommand(shell, 'pnpm run build');


### PR DESCRIPTION
Closes #248 

As title suggest, this PR fixes command skipping on deploy. this bug is caused by using the wrong method in the #245
 