### PR TITLE
fix: kick after ^C for OSC code properly

### DIFF
--- a/app/lib/container/remote-container.ts
+++ b/app/lib/container/remote-container.ts
@@ -1304,31 +1304,31 @@ export class RemoteContainer implements Container {
 
       // Command execution implementation
       executeCommand = async (command: string): Promise<ExecutionResult> => {
-        logger.debug('executeCommand', command);
+        const sessionId = v4().slice(0, 8);
+
+        logger.debug(`[${sessionId}] executeCommand`, command);
 
         // Interrupt current execution
         terminal.input('\x03');
 
-        logger.debug('waiting for prompt', command);
+        // Kick the shell to retrieve the prompt properly
+        terminal.input('\n');
+
+        logger.debug(`[${sessionId}] waiting for prompt`, command);
 
         // Wait for prompt
         await waitTillOscCode('prompt');
 
-        logger.debug('prompt received', command);
-
-        // Execute new command
-        terminal.input(':' + '\n');
-        await waitTillOscCode('exit');
-        logger.debug('terminal is responsive');
+        logger.debug(`[${sessionId}] prompt received`, command);
 
         terminal.input(command.trim() + '\n');
 
-        logger.debug('command executed', command);
+        logger.debug(`[${sessionId}] command executed`, command);
 
         // Wait for execution result
         const { output, exitCode } = await waitTillOscCode('exit');
 
-        logger.debug('execution ended', command, exitCode);
+        logger.debug(`[${sessionId}] execution ended`, command, exitCode);
 
         return {
           output: cleanTerminalOutput(output),


### PR DESCRIPTION
Closes #252 

As title suggests, this PR fixes the kick code for terminal, to wait prompt OSC properly.