### PR TITLE
fix: prevent shell queue blocking by dev server

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -55,7 +55,6 @@ import { useGitbaseChatHistory } from '~/lib/persistenceGitbase/useGitbaseChatHi
 import { isCommitHash } from '~/lib/persistenceGitbase/utils';
 import { extractTextContent } from '~/utils/message';
 import { changeChatUrl } from '~/utils/url';
-import { SETTINGS_KEYS } from '~/lib/stores/settings';
 import { get2DStarterPrompt, get3DStarterPrompt } from '~/lib/common/prompts/agent8-prompts';
 import { stripMetadata } from './UserMessage';
 import type { ProgressAnnotation } from '~/types/context';
@@ -329,17 +328,7 @@ export const ChatImpl = memo(
         break;
       }
 
-      await workbench.setupDeployConfig(shell);
-
-      const container = await workbench.container;
-      await shell.executeCommand(Date.now().toString(), `cd ${container.workdir}`);
-      await shell.waitTillOscCode('prompt');
-
-      if (localStorage.getItem(SETTINGS_KEYS.AGENT8_DEPLOY) === 'false') {
-        shell.executeCommand(Date.now().toString(), 'bun update && bun run dev');
-      } else {
-        shell.executeCommand(Date.now().toString(), 'bun update && npx -y @agent8/deploy --preview && bun run dev');
-      }
+      await workbench.runPreview();
     };
 
     const lastSendMessageTime = useRef(0);

--- a/app/components/header/HeaderActionButtons.client.tsx
+++ b/app/components/header/HeaderActionButtons.client.tsx
@@ -12,6 +12,7 @@ import type { ActionCallbackData } from '~/lib/runtime/message-parser';
 import { streamingState } from '~/lib/stores/streaming';
 import { NetlifyDeploymentLink } from '~/components/chat/NetlifyDeploymentLink.client';
 import { repoStore } from '~/lib/stores/repo';
+import { SHELL_COMMANDS } from '~/utils/constants';
 interface HeaderActionButtonsProps {}
 
 export function HeaderActionButtons({}: HeaderActionButtonsProps) {
@@ -68,7 +69,7 @@ export function HeaderActionButtons({}: HeaderActionButtonsProps) {
         actionId,
         action: {
           type: 'build' as const,
-          content: 'bun run build',
+          content: SHELL_COMMANDS.BUILD_PROJECT,
         },
       };
 

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -93,6 +93,12 @@ export const TOOL_NAMES = {
   READ_FILES_CONTENTS: 'read_files_contents',
 } as const;
 
+export const SHELL_COMMANDS = {
+  UPDATE_DEPENDENCIES: 'bun update',
+  START_DEV_SERVER: 'bun run dev',
+  BUILD_PROJECT: 'bun run build',
+} as const;
+
 export const ATTACHMENT_EXTS = [
   '.png',
   '.jpg',


### PR DESCRIPTION
  - Track dev server state with #devServerRunning flag
  - Auto-interrupt dev server before new commands
  - Extract shell commands as semantic constants
  - Bypass queue for long-running dev server process

  Resolves infinite loading when file actions wait for dev server prompt.

Closes: #370 