### PR TITLE
fix: update pnpm-lock.yaml to resolve CI lockfile mismatch

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   '@typescript-eslint/utils': ^8.0.0-alpha.30
-  binary-extensions: 2.3.0
 
 importers:
 


### PR DESCRIPTION
## Overview

Fixes CI build failure caused by `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` error.

## Changes

- Synchronized `pnpm-lock.yaml` with `package.json` resolutions configuration