### PR TITLE
 feat: disable thinking output for Google Vertex AI provider

### DIFF
--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -37,7 +37,6 @@ import { createInvalidToolInputHandler } from './tools/error-handle';
 import { createSubmitArtifactActionTool } from './tools/action';
 import { createUnknownToolHandler } from './tools/error-handle';
 import { is3dProject } from '~/lib/utils';
-import type { GoogleGenerativeAIProviderOptions } from '@ai-sdk/google';
 
 export type Messages = UIMessage[];
 
@@ -199,15 +198,6 @@ export async function streamText(props: {
     }),
     abortSignal,
     maxOutputTokens: dynamicMaxTokens,
-    providerOptions: {
-      google: {
-        // Options are nested under 'google' for Vertex provider
-        thinkingConfig: {
-          includeThoughts: false,
-          thinkingBudget: -1,
-        },
-      } satisfies GoogleGenerativeAIProviderOptions,
-    },
     stopWhen: [stepCountIs(15), hasToolCall(TOOL_NAMES.SUBMIT_ARTIFACT)],
     messages: coreMessages,
     tools: combinedTools,

--- a/app/lib/modules/llm/providers/google-vertex.ts
+++ b/app/lib/modules/llm/providers/google-vertex.ts
@@ -727,6 +727,25 @@ export default class GoogleVertexProvider extends BaseProvider {
     const originalFetch = globalThis.fetch;
 
     return async (url, init) => {
+      // Modify request body to add default thinkingConfig if not already set
+      if (init?.body) {
+        try {
+          const body = JSON.parse(init.body as string);
+
+          // Add thinkingConfig to generationConfig only if not already present
+          if (body.generationConfig && !body.generationConfig.thinkingConfig) {
+            body.generationConfig.thinkingConfig = {
+              includeThoughts: false,
+              thinkingBudget: -1,
+            };
+          }
+
+          init.body = JSON.stringify(body);
+        } catch (error) {
+          logger.warn('Failed to modify request body:', error);
+        }
+      }
+
       const response = await originalFetch(url, init);
 
       if (!response.ok) {


### PR DESCRIPTION
  - Add thinkingConfig to Vertex AI provider options
  - Set includeThoughts to false to exclude thinking process
  - Set thinkingBudget to -1 for unlimited thinking budget