### PR TITLE
feat(chat): add server-to-client debug logging for LLM streaming

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -82,7 +82,7 @@ const WORKBENCH_MESSAGE_IDLE_TIMEOUT_MS = 35000;
 
 // const AUTO_SYNTAX_FIX_IDLE_TIMEOUT_MS = 60000;
 
-// 49 debug logs
+// 50 debug logs
 function addDebugLog(value: number | string): void {
   logManager.add('Chat-' + value);
 }
@@ -731,6 +731,15 @@ export const ChatImpl = memo(
 
         // Extract the inner 'data' property if it exists
         const extractedData = data.data || data;
+
+        // Handle data-log (server-side logs)
+        if (data.type === 'data-log') {
+          if (extractedData && typeof extractedData === 'object' && 'message' in extractedData) {
+            addDebugLog(`50:${(extractedData as { message: string }).message}`);
+          }
+
+          return;
+        }
 
         // Handle server-side errors (data-error with reason and message)
         if (data.type === 'data-error' && isServerError(extractedData)) {

--- a/app/types/stream-events.ts
+++ b/app/types/stream-events.ts
@@ -14,5 +14,25 @@ export interface ServerErrorData {
  */
 export type DataErrorPayload = {
   type: 'data-error';
+  transient?: boolean;
   data: ServerErrorData;
+};
+
+export type DataLogPayload = {
+  type: 'data-log';
+  transient: boolean;
+  data: { message: string };
+};
+
+export type DataProgressPayload = {
+  type: 'data-progress';
+  transient: boolean;
+  data: {
+    type: 'progress';
+    status: 'in-progress' | 'complete' | 'failed';
+    order: number;
+    message: string;
+    label?: string;
+    percentage?: number;
+  };
 };


### PR DESCRIPTION
- Add DataLogPayload and DataProgressPayload types for stream events
- Create helper functions (createDataError, createDataLog, createDataProgress)
- Add onDebugLog callback to streamText for tracking LLM processing stages
- Handle data-log events in Chat component to receive server-side logs
- Refactor inline payload objects to use centralized helper functions