### PR TITLE
Improve Turnstile stability and error handling

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -917,7 +917,8 @@ export const ChatImpl = memo(
           })
           .catch((error) => {
             const isAborted = isAbortError(error) || sendMessageAbortControllerRef.current?.signal?.aborted;
-            if(isAborted) {
+
+            if (isAborted) {
               logger.info('Setup deploy config aborted by user');
               return;
             }

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -1230,6 +1230,7 @@ export class WorkbenchStore {
     };
 
     checkAborted();
+
     // Get access token
     const accessToken = localStorage.getItem(V8_ACCESS_TOKEN_KEY);
 
@@ -1238,22 +1239,27 @@ export class WorkbenchStore {
     }
 
     checkAborted();
+
     // Verify user
     const user = await verifyV8AccessToken(import.meta.env.VITE_V8_AUTH_API_ENDPOINT, accessToken);
-    
+
     checkAborted();
+
     if (!user.isActivated) {
       throw new Error('Account is not activated');
     }
 
     checkAborted();
+
     // Setup environment
     await this.injectTokenEnvironment(shell, accessToken);
 
     checkAborted();
+
     const verseId = await this.setupEnvFile(user, options.reset);
 
     checkAborted();
+
     return { user, verseId };
   }
 

--- a/app/types/global.d.ts
+++ b/app/types/global.d.ts
@@ -3,7 +3,9 @@ interface TurnstileRenderOptions {
   sitekey: string;
   callback?: (token: string) => void;
   'expired-callback'?: () => void;
-  'error-callback'?: () => boolean | void;
+  'error-callback'?: (errorCode: string) => boolean | void;
+  'timeout-callback'?: () => boolean | void;
+  'unsupported-callback'?: () => void;
   'before-interactive-callback'?: () => void;
   'after-interactive-callback'?: () => void;
   theme?: 'light' | 'dark' | 'auto';


### PR DESCRIPTION
Changes

Auto-retry on failure
- Changed retry: 'never' to retry: 'auto' with 3s interval
- Reduces failure rate from transient network/CF issues

15s challenge timeout
- Prevents indefinite waiting (CF default is 5 min)
- Returns clear timeout error for better UX

Remove reset() usage
- Always remove() → render() to avoid https://community.clou
dflare.com/t/bug-widget-not-displayed-in-interaction-only-mo
de-after-turnstile-reset-usability-suggestion/579897

Add missing callbacks per official docs
- error-callback with error code logging
- timeout-callback, unsupported-callback
- after-interactive-callback for immediate modal close

Expected Results

- Lower failure rate with auto-retry
- Better debugging with error codes
- Reliable widget display on repeated requests
- Graceful handling of unsupported browsers