### PR TITLE
fix: publish error(agent8-old)

### DIFF
--- a/app/lib/container/interfaces.ts
+++ b/app/lib/container/interfaces.ts
@@ -97,7 +97,7 @@ export interface ShellSession {
   ready: Promise<void>;
 
   executeCommand?(command: string, signal?: AbortSignal): Promise<ExecutionResult>;
-  waitTillOscCode?(code: string): Promise<{ output: string; exitCode: number }>;
+  waitTillOscCode?(code: string, signal?: AbortSignal): Promise<{ output: string; exitCode: number }>;
   detachTerminal?(): void;
   attachTerminal?(terminal: ITerminal): Promise<void>;
 }

--- a/app/lib/container/interfaces.ts
+++ b/app/lib/container/interfaces.ts
@@ -96,7 +96,7 @@ export interface ShellSession {
   internalOutput?: ReadableStream<string>;
   ready: Promise<void>;
 
-  executeCommand?(command: string): Promise<ExecutionResult>;
+  executeCommand?(command: string, signal?: AbortSignal): Promise<ExecutionResult>;
   waitTillOscCode?(code: string): Promise<{ output: string; exitCode: number }>;
   detachTerminal?(): void;
   attachTerminal?(terminal: ITerminal): Promise<void>;

--- a/app/lib/container/remote-container.ts
+++ b/app/lib/container/remote-container.ts
@@ -1318,6 +1318,18 @@ export class RemoteContainer implements Container {
       try {
         isWaitingForOscCode = true;
 
+        const abortHandler = () => {
+          reader
+            .cancel('Operation aborted by user')
+            .then(() => {
+              logger.debug('stream reader cancelled by user');
+            })
+            .catch(() => {
+              // stream reader is already closed, ignore error
+            });
+        };
+        signal?.addEventListener('abort', abortHandler);
+
         streamReadTimeoutId = setTimeout(() => {
           currentTerminal?.input(':' + '\n');
         }, STREAM_READ_IDLE_TIMEOUT_MS);

--- a/app/lib/hooks/useWorkbenchStore.ts
+++ b/app/lib/hooks/useWorkbenchStore.ts
@@ -81,6 +81,11 @@ export function useWorkbenchIsDeploying() {
   return useStore(workbenchStore.isDeploying);
 }
 
+export function useWorkbenchIsRunningPreview() {
+  useStore(reinitCounterAtom);
+  return useStore(workbenchStore.isRunningPreview);
+}
+
 export function useWorkbenchContainer() {
   useStore(reinitCounterAtom);
   return useStore(workbenchStore.containerAtom);

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -1220,8 +1220,6 @@ export class WorkbenchStore {
       .map(([key, value]) => `${key}=${value}`)
       .join('\n');
 
-    checkAborted();
-
     await this.#filesStore.saveFile('.env', updatedEnvContent);
     checkAborted();
 
@@ -1283,8 +1281,6 @@ export class WorkbenchStore {
     if (!user.isActivated) {
       throw new Error('Account is not activated');
     }
-
-    checkAborted();
 
     // Setup environment
     await this.injectTokenEnvironment(shell, accessToken, signal);

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -34,7 +34,7 @@ import { SETTINGS_KEYS } from './settings';
 import { toast } from 'react-toastify';
 import { isCommitedMessage } from '~/lib/persistenceGitbase/utils';
 import { convertFileMapToFileSystemTree } from '~/utils/fileUtils';
-import { DeployError, StatusCodeError } from '~/utils/errors';
+import { DeployError, isAbortError, StatusCodeError } from '~/utils/errors';
 
 const { saveAs } = fileSaver;
 
@@ -90,6 +90,8 @@ export class WorkbenchStore {
   #messageIdleCallbacks: Map<string, Array<() => void>> = new Map();
   #reinitCounter = atom(0);
   #currentContainerAtom: WritableAtom<Container | null> = atom<Container | null>(null);
+  #runPreviewAbortController: AbortController | null = null;
+  #publishAbortController: AbortController | null = null;
 
   artifacts: Artifacts = import.meta.hot?.data.artifacts ?? map({});
 
@@ -105,6 +107,7 @@ export class WorkbenchStore {
   connectionState: WritableAtom<'connected' | 'disconnected' | 'reconnecting' | 'failed'> =
     import.meta.hot?.data.connectionState ??
     atom<'connected' | 'disconnected' | 'reconnecting' | 'failed'>('disconnected');
+  isRunningPreview: WritableAtom<boolean> = import.meta.hot?.data.isRunningPreview ?? atom(false);
   isDeploying: WritableAtom<boolean> = import.meta.hot?.data.isDeploying ?? atom(false);
   modifiedFiles = new Set<string>();
   artifactIdList: string[] = [];
@@ -591,9 +594,12 @@ export class WorkbenchStore {
     this.#filesStore.resetFileModifications();
   }
 
-  abortAllActions() {
-    // 1. Process and clear all message action queues
-    for (const queueItem of this.#messageToActionQueue.values()) {
+  async abortAllActions() {
+    // Process and clear all message action queues
+    const queueSnapshot = new Map(this.#messageToActionQueue);
+    this.#messageToActionQueue.clear();
+
+    for (const queueItem of queueSnapshot.values()) {
       if (queueItem) {
         // Traverse the linked list and abort all actions
         let current: ActionQueueItem | undefined = queueItem;
@@ -631,13 +637,17 @@ export class WorkbenchStore {
       }
     }
 
-    this.#messageToActionQueue.clear();
-
-    // 2. Abort shell commands
+    this.#runPreviewAbortController?.abort();
+    this.#publishAbortController?.abort();
     this.#shellAbortController?.abort();
+
+    // Abort stabilization time
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    this.#runPreviewAbortController = null;
+    this.#publishAbortController = null;
     this.#shellAbortController = null;
 
-    // 3. Reset shell command queue
     this.#shellCommandQueue = Promise.resolve();
   }
 
@@ -894,9 +904,6 @@ export class WorkbenchStore {
       return;
     }
 
-    // Wait for any ongoing shell commands (setupDeployConfig, publish, etc.) to complete
-    await this.#shellCommandQueue;
-
     if (data.action.type === 'file') {
       const wc = await this.container;
       const fullPath = path.join(wc.workdir, data.action.filePath);
@@ -1129,26 +1136,52 @@ export class WorkbenchStore {
     return result;
   }
 
-  async injectTokenEnvironment(shell: BoltShell, accessToken: string) {
+  async injectTokenEnvironment(shell: BoltShell, accessToken: string, signal?: AbortSignal) {
+    const checkAborted = () => {
+      if (signal?.aborted) {
+        throw new DOMException('Inject token environment aborted by user', ERROR_NAMES.ABORT);
+      }
+    };
+
+    checkAborted();
+
     const wc = await this.container;
+
+    checkAborted();
 
     try {
       const setupScript = '#!/bin/sh\n\nexport V8_ACCESS_TOKEN="' + accessToken + '"';
       await wc.fs.writeFile('.secret', setupScript);
-      await this.#runShellCommand(shell, 'source ./.secret && rm -f ./.secret');
-    } catch {
+      checkAborted();
+
+      await this.#runShellCommand(shell, 'source ./.secret && rm -f ./.secret', signal);
+    } catch (error) {
+      if (isAbortError(error)) {
+        logger.debug('inject token environment aborted by user');
+        return;
+      }
+
       throw new Error('Failed to inject user data into the shell.');
     } finally {
-      try {
-        await wc.fs.rm('.secret');
-      } catch {
-        // File might not exist yet, continue with empty content
-      }
+      await wc.fs.rm('.secret').catch(() => {
+        // File might not exist or removal failed, ignore the error
+      });
     }
   }
 
-  async setupEnvFile(user: V8User, reset: boolean = false) {
+  async setupEnvFile(user: V8User, reset: boolean = false, signal?: AbortSignal) {
+    const checkAborted = () => {
+      if (signal?.aborted) {
+        throw new DOMException('Setup env file aborted by user', ERROR_NAMES.ABORT);
+      }
+    };
+
+    checkAborted();
+
     const wc = await this.container;
+
+    checkAborted();
+
     const files = this.files.get();
 
     if (!files || Object.keys(files).length === 0) {
@@ -1157,6 +1190,8 @@ export class WorkbenchStore {
 
     let envFile = (files[`${WORK_DIR}/.env`] as File)?.content || '';
 
+    checkAborted();
+
     try {
       if (!envFile) {
         envFile = await wc.fs.readFile('.env', 'utf-8');
@@ -1164,6 +1199,8 @@ export class WorkbenchStore {
     } catch {
       // File might not exist yet, continue with empty content
     }
+
+    checkAborted();
 
     // Parse existing environment variables
     const envVars = this.#parseEnvFile(envFile);
@@ -1179,6 +1216,8 @@ export class WorkbenchStore {
       return currentVerse;
     }
 
+    checkAborted();
+
     envVars.VITE_AGENT8_ACCOUNT = user.walletAddress || user.userUid;
 
     const verseId = generateVerseId(envVars.VITE_AGENT8_ACCOUNT);
@@ -1188,7 +1227,10 @@ export class WorkbenchStore {
       .map(([key, value]) => `${key}=${value}`)
       .join('\n');
 
+    checkAborted();
+
     await this.#filesStore.saveFile('.env', updatedEnvContent);
+    checkAborted();
 
     return verseId;
   }
@@ -1241,7 +1283,7 @@ export class WorkbenchStore {
     checkAborted();
 
     // Verify user
-    const user = await verifyV8AccessToken(import.meta.env.VITE_V8_AUTH_API_ENDPOINT, accessToken);
+    const user = await verifyV8AccessToken(import.meta.env.VITE_V8_AUTH_API_ENDPOINT, accessToken, signal);
 
     checkAborted();
 
@@ -1252,11 +1294,11 @@ export class WorkbenchStore {
     checkAborted();
 
     // Setup environment
-    await this.injectTokenEnvironment(shell, accessToken);
+    await this.injectTokenEnvironment(shell, accessToken, signal);
 
     checkAborted();
 
-    const verseId = await this.setupEnvFile(user, options.reset);
+    const verseId = await this.setupEnvFile(user, options.reset, signal);
 
     checkAborted();
 
@@ -1264,34 +1306,72 @@ export class WorkbenchStore {
   }
 
   async runPreview() {
-    this.currentView.set('code');
-
-    const shell = this.boltTerminal;
-    await shell.ready;
+    if (this.isRunningPreview.get()) {
+      return;
+    }
 
     try {
-      await this.setupDeployConfig(shell);
+      this.isRunningPreview.set(true);
+
+      await this.abortAllActions();
+
+      this.#runPreviewAbortController = new AbortController();
+
+      const signal = this.#runPreviewAbortController.signal;
+
+      const checkAborted = () => {
+        if (signal?.aborted) {
+          throw new DOMException('Run preview aborted by user', ERROR_NAMES.ABORT);
+        }
+      };
+
+      checkAborted();
+
+      this.currentView.set('code');
+
+      checkAborted();
+
+      const shell = this.boltTerminal;
+      await shell.ready;
+
+      checkAborted();
+
+      await this.setupDeployConfig(shell, signal);
+
+      checkAborted();
 
       // Navigate to working directory
       const container = await this.container;
 
-      await this.#runShellCommand(shell, `cd ${container.workdir}`);
+      checkAborted();
+
+      await this.#runShellCommand(shell, `cd ${container.workdir}`, signal);
+
+      checkAborted();
 
       // Run development server
       if (localStorage.getItem(SETTINGS_KEYS.AGENT8_DEPLOY) === 'false') {
-        shell.executeCommand(
-          Date.now().toString(),
-          `${SHELL_COMMANDS.UPDATE_DEPENDENCIES} && ${SHELL_COMMANDS.START_DEV_SERVER}`,
-        );
+        await this.#runShellCommand(shell, SHELL_COMMANDS.UPDATE_DEPENDENCIES, signal);
+        checkAborted();
+        await this.#runShellCommand(shell, SHELL_COMMANDS.START_DEV_SERVER, signal);
       } else {
-        shell.executeCommand(
-          Date.now().toString(),
-          `${SHELL_COMMANDS.UPDATE_DEPENDENCIES} && npx -y @agent8/deploy --preview && ${SHELL_COMMANDS.START_DEV_SERVER}`,
-        );
+        await this.#runShellCommand(shell, SHELL_COMMANDS.UPDATE_DEPENDENCIES, signal);
+        checkAborted();
+        await this.#runShellCommand(shell, 'npx -y @agent8/deploy --preview', signal);
+        checkAborted();
+        await this.#runShellCommand(shell, SHELL_COMMANDS.START_DEV_SERVER, signal);
       }
     } catch (error) {
+      if (isAbortError(error)) {
+        logger.info('runPreview aborted by user');
+        return;
+      }
+
       logger.error('[RunPreview] Error:', error);
       throw error;
+    } finally {
+      this.#runPreviewAbortController = null;
+      this.isRunningPreview.set(false);
     }
   }
 
@@ -1304,28 +1384,57 @@ export class WorkbenchStore {
 
     try {
       this.isDeploying.set(true);
+
+      await this.abortAllActions();
+
+      this.#publishAbortController = new AbortController();
+
+      const signal = this.#publishAbortController.signal;
+
+      const checkAborted = () => {
+        if (signal?.aborted) {
+          throw new DOMException('Publish aborted by user', ERROR_NAMES.ABORT);
+        }
+      };
+
+      checkAborted();
+
       this.currentView.set('code');
+
+      checkAborted();
 
       const shell = this.boltTerminal;
       await shell.ready;
 
+      checkAborted();
+
       // Install dependencies
-      await this.#runShellCommand(shell, 'rm -rf dist');
-      await this.#runShellCommand(shell, SHELL_COMMANDS.UPDATE_DEPENDENCIES);
+      await this.#runShellCommand(shell, 'rm -rf dist', signal);
+      checkAborted();
+
+      await this.#runShellCommand(shell, SHELL_COMMANDS.UPDATE_DEPENDENCIES, signal);
+      checkAborted();
 
       if (localStorage.getItem(SETTINGS_KEYS.AGENT8_DEPLOY) === 'false') {
         toast.error('Agent8 deploy is disabled. Please enable it in the settings.');
         return;
       }
 
-      const { verseId } = await this.setupDeployConfig(shell);
-      await this.commitModifiedFiles();
+      const { verseId } = await this.setupDeployConfig(shell, signal);
+      checkAborted();
+
+      await this.commitModifiedFiles(signal);
+      checkAborted();
 
       const container = await this.container;
-      await this.#runShellCommand(shell, `cd ${container.workdir}`);
+      checkAborted();
+
+      await this.#runShellCommand(shell, `cd ${container.workdir}`, signal);
+      checkAborted();
 
       // Build project
-      const buildResult = await this.#runShellCommand(shell, `${SHELL_COMMANDS.BUILD_PROJECT} --base ./`);
+      const buildResult = await this.#runShellCommand(shell, `${SHELL_COMMANDS.BUILD_PROJECT} --base ./`, signal);
+      checkAborted();
 
       if (buildResult?.exitCode === 2) {
         this.#handleBuildError(buildResult.output);
@@ -1333,6 +1442,7 @@ export class WorkbenchStore {
       }
 
       const wc = await this.container;
+      checkAborted();
 
       let buildFile = '';
 
@@ -1342,6 +1452,7 @@ export class WorkbenchStore {
         failedReason = 'read build file';
         console.error('Failed to read build file', error);
       }
+      checkAborted();
 
       if (!buildFile) {
         failedReason = 'no build file';
@@ -1350,6 +1461,7 @@ export class WorkbenchStore {
 
       // Deploy project
       const deployResult = await this.#runShellCommand(shell, 'npx -y @agent8/deploy --prod');
+      checkAborted();
 
       if (deployResult?.exitCode !== 0) {
         throw new Error();
@@ -1364,6 +1476,7 @@ export class WorkbenchStore {
         failedReason = 'task not found';
         throw error;
       }
+      checkAborted();
 
       const { tags } = await getTags(repoStore.get().path);
       const spinTag = tags.find((tag: any) => tag.name.startsWith('verse-from'));
@@ -1373,32 +1486,44 @@ export class WorkbenchStore {
         parentVerseId = spinTag.name.replace('verse-from-', '').trim();
       }
 
+      checkAborted();
+
       // Handle successful deployment
       this.#handleSuccessfulDeployment(verseId, chatId, title, lastCommitHash, parentVerseId);
     } catch (error) {
+      if (isAbortError(error)) {
+        logger.debug('publish aborted by user');
+        return;
+      }
+
       const errorMessage = 'Failed to publish';
       logger.error('[Publish] Error:', error);
       throw new DeployError(failedReason ? `${errorMessage}: ${failedReason}` : errorMessage);
     } finally {
       this.isDeploying.set(false);
+      this.#publishAbortController = null;
     }
   }
 
   // Helper methods for publish
-  async #runShellCommand(shell: BoltShell, command: string) {
-    // Create abort controller for this command
-    this.#shellAbortController = new AbortController();
+  async #runShellCommand(shell: BoltShell, command: string, parentSignal?: AbortSignal) {
+    const checkAborted = () => {
+      if (parentSignal?.aborted) {
+        throw new DOMException('Run shell command aborted by user', ERROR_NAMES.ABORT);
+      }
+    };
 
-    const signal = this.#shellAbortController.signal;
-
-    // Queue all shell commands to prevent interference
     this.#shellCommandQueue = this.#shellCommandQueue.then(async () => {
-      const abortPromise = new Promise<never>((_, reject) => {
-        signal.addEventListener('abort', () => reject(new DOMException('Aborted', ERROR_NAMES.ABORT)), { once: true });
-      });
+      checkAborted();
 
-      const result = await Promise.race([shell.executeCommand(Date.now().toString(), command), abortPromise]);
-      await Promise.race([shell.waitTillOscCode('prompt'), abortPromise]);
+      // executeCommand가 signal을 처리하므로 race 불필요
+      const result = await shell.executeCommand(Date.now().toString(), command, undefined, { signal: parentSignal });
+
+      checkAborted();
+
+      await shell.waitTillOscCode('prompt');
+
+      checkAborted();
 
       return result;
     });

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -1338,20 +1338,19 @@ export class WorkbenchStore {
 
       // Run development server
       if (localStorage.getItem(SETTINGS_KEYS.AGENT8_DEPLOY) === 'false') {
-        await this.#runShellCommand(shell, SHELL_COMMANDS.UPDATE_DEPENDENCIES, signal);
+        await this.#runShellCommand(
+          shell,
+          `${SHELL_COMMANDS.UPDATE_DEPENDENCIES} && ${SHELL_COMMANDS.START_DEV_SERVER}`,
+          signal,
+        );
         checkAborted();
-
-        // Start the development server without waiting for completion (long-running process)
-        this.#runShellCommand(shell, SHELL_COMMANDS.START_DEV_SERVER, signal);
       } else {
-        await this.#runShellCommand(shell, SHELL_COMMANDS.UPDATE_DEPENDENCIES, signal);
+        await this.#runShellCommand(
+          shell,
+          `${SHELL_COMMANDS.UPDATE_DEPENDENCIES} && npx -y @agent8/deploy --preview && ${SHELL_COMMANDS.START_DEV_SERVER}`,
+          signal,
+        );
         checkAborted();
-
-        await this.#runShellCommand(shell, `npx -y @agent8/deploy --preview`, signal);
-        checkAborted();
-
-        // Start the development server without waiting for completion (long-running process)
-        this.#runShellCommand(shell, SHELL_COMMANDS.START_DEV_SERVER, signal);
       }
     } catch (error) {
       if (isAbortError(error)) {

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -1342,17 +1342,20 @@ export class WorkbenchStore {
 
       // Run development server
       if (localStorage.getItem(SETTINGS_KEYS.AGENT8_DEPLOY) === 'false') {
-        await this.#runShellCommand(
-          shell,
-          `${SHELL_COMMANDS.UPDATE_DEPENDENCIES} && ${SHELL_COMMANDS.START_DEV_SERVER}`,
-          signal,
-        );
+        await this.#runShellCommand(shell, SHELL_COMMANDS.UPDATE_DEPENDENCIES, signal);
+        checkAborted();
+
+        await this.#runShellCommand(shell, SHELL_COMMANDS.START_DEV_SERVER, signal);
+        checkAborted();
       } else {
-        await this.#runShellCommand(
-          shell,
-          `${SHELL_COMMANDS.UPDATE_DEPENDENCIES} && npx -y @agent8/deploy --preview && ${SHELL_COMMANDS.START_DEV_SERVER}`,
-          signal,
-        );
+        await this.#runShellCommand(shell, SHELL_COMMANDS.UPDATE_DEPENDENCIES, signal);
+        checkAborted();
+
+        await this.#runShellCommand(shell, `npx -y @agent8/deploy --preview`, signal);
+        checkAborted();
+
+        await this.#runShellCommand(shell, SHELL_COMMANDS.START_DEV_SERVER, signal);
+        checkAborted();
       }
 
       checkAborted();

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -1345,8 +1345,8 @@ export class WorkbenchStore {
         await this.#runShellCommand(shell, SHELL_COMMANDS.UPDATE_DEPENDENCIES, signal);
         checkAborted();
 
-        await this.#runShellCommand(shell, SHELL_COMMANDS.START_DEV_SERVER, signal);
-        checkAborted();
+        // Start the development server without waiting for completion (long-running process)
+        this.#runShellCommand(shell, SHELL_COMMANDS.START_DEV_SERVER, signal);
       } else {
         await this.#runShellCommand(shell, SHELL_COMMANDS.UPDATE_DEPENDENCIES, signal);
         checkAborted();
@@ -1354,11 +1354,9 @@ export class WorkbenchStore {
         await this.#runShellCommand(shell, `npx -y @agent8/deploy --preview`, signal);
         checkAborted();
 
-        await this.#runShellCommand(shell, SHELL_COMMANDS.START_DEV_SERVER, signal);
-        checkAborted();
+        // Start the development server without waiting for completion (long-running process)
+        this.#runShellCommand(shell, SHELL_COMMANDS.START_DEV_SERVER, signal);
       }
-
-      checkAborted();
     } catch (error) {
       if (isAbortError(error)) {
         logger.info('runPreview aborted by user');

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -36,6 +36,7 @@ import { isCommitedMessage } from '~/lib/persistenceGitbase/utils';
 import { convertFileMapToFileSystemTree } from '~/utils/fileUtils';
 import { DeployError, isAbortError, StatusCodeError } from '~/utils/errors';
 
+const WORKBENCH_ACTION_ABORT_DELAY_MS = 150;
 const { saveAs } = fileSaver;
 
 const logger = createScopedLogger('workbench');
@@ -642,7 +643,7 @@ export class WorkbenchStore {
     this.#shellAbortController?.abort();
 
     // Abort stabilization time
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await new Promise((resolve) => setTimeout(resolve, WORKBENCH_ACTION_ABORT_DELAY_MS));
 
     this.#runPreviewAbortController = null;
     this.#publishAbortController = null;

--- a/app/utils/errors.ts
+++ b/app/utils/errors.ts
@@ -62,6 +62,13 @@ export class MachineAPIError extends StatusCodeError {
   }
 }
 
+export class NoneError extends Error {
+  constructor(message: string = 'None error') {
+    super(message);
+    this.name = 'NoneError';
+  }
+}
+
 /**
  * Helper function to check if an error is an abort/cancel error
  * Supports: DOMException (fetch), CanceledError (axios)

--- a/app/utils/shell.ts
+++ b/app/utils/shell.ts
@@ -2,6 +2,7 @@ import type { Container, ExecutionResult, ShellSession } from '~/lib/container/i
 import type { ITerminal } from '~/types/terminal';
 import { atom } from 'nanostores';
 import { createScopedLogger } from '~/utils/logger';
+import { ERROR_NAMES } from './constants';
 
 const logger = createScopedLogger('BoltShell');
 
@@ -164,9 +165,13 @@ export class BoltShell {
     return { output, exitCode };
   }
 
-  async waitTillOscCode(waitCode: string) {
+  async waitTillOscCode(waitCode: string, signal?: AbortSignal) {
+    if (signal?.aborted) {
+      throw new DOMException('Wait till OSC code aborted by user', ERROR_NAMES.ABORT);
+    }
+
     if (this.#shellSession && this.#shellSession.waitTillOscCode) {
-      return await this.#shellSession.waitTillOscCode(waitCode);
+      return await this.#shellSession.waitTillOscCode(waitCode, signal);
     } else {
       throw new Error('BoltShell does not support waitTillOscCode');
     }

--- a/app/utils/shell.ts
+++ b/app/utils/shell.ts
@@ -222,6 +222,41 @@ export class BoltShell {
 }
 
 /**
+ * Checks if a command is a non-terminating process that runs indefinitely
+ * @param command - The shell command to check
+ * @returns true if the command runs indefinitely without manual interruption
+ */
+export function isNonTerminatingCommand(command: string): boolean {
+  const patterns = [
+    // Development servers - never exit until manually stopped
+    /\b(npm|yarn|pnpm|bun)\s+(?:run\s+)?dev\b/i,
+    /\b(vite|next|remix)\s+dev\b/i,
+    /\bwebpack(?:-dev-server)?\s+serve\b/i,
+
+    // Preview/static servers - serve files indefinitely
+    /\b(npm|yarn|pnpm|bun)\s+(?:run\s+)?preview\b/i,
+    /\bvite\s+preview\b/i,
+    /\b(http-server|serve)\b/i,
+    /python3?\s+-m\s+http\.server/i,
+
+    // Watch modes - continuously watch for changes
+    /\b(?:--watch|-w)\b/,
+    /\bvitest\b/i, // vitest runs in watch mode by default
+
+    // Process managers - keep processes running
+    /\b(nodemon|pm2|forever)\b/i,
+
+    // Monitoring commands - continuously monitor output
+    /\btail\s+-f\b/,
+    /\bwatch\s+/,
+  ];
+
+  const lastCommand = command.split('&&').pop()?.trim() ?? command;
+
+  return patterns.some((pattern) => pattern.test(lastCommand));
+}
+
+/**
  * Cleans and formats terminal output while preserving structure and paths
  * Handles ANSI, OSC, and various terminal control sequences
  */


### PR DESCRIPTION
Close: https://github.com/planetarium/agent8/issues/753

- Add hook to check if preview is running
- Enhance command execution with abort signal support
- Replace hardcoded delay with constant for abort stabilization

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes terminal/shell execution and cancellation behavior used by `runPreview`/`publish`, which can impact command sequencing and error handling during deploy flows.
> 
> **Overview**
> **Adds end-to-end cancellation for shell-driven workflows.** `ShellSession`, `RemoteContainer` OSC waiting, and `BoltShell` command execution now accept an `AbortSignal`, and `workbench` threads that signal through `setupDeployConfig`, token/env setup, and `#runShellCommand`.
> 
> **Hardens preview/publish behavior.** `WorkbenchStore` introduces `isRunningPreview` (plus `useWorkbenchIsRunningPreview`) and separate abort controllers for preview vs publish, proactively aborting in-flight actions/commands before starting those flows and ensuring flags/controllers reset in `finally`.
> 
> **Improves robustness around non-terminating commands.** Adds `isNonTerminatingCommand` and a `NoneError` path to avoid indefinite OSC waits/timeouts when a long-lived process (e.g., dev server/watch) is running, and updates `abortAllActions` to clear action queues via a snapshot to prevent re-entrancy issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c814dca54fa39cbe895e3bf80dd11b26590bd104. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->