### PR TITLE
fix: defer API calls until INIT message on origin change

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -209,11 +209,21 @@ interface ChatComponentProps {
   isAuthenticated?: boolean;
   onAuthRequired?: () => void;
   handleStopRef?: React.MutableRefObject<(() => void) | null>;
+  hasReceivedInit?: boolean;
 }
 
-export function Chat({ isAuthenticated, onAuthRequired, handleStopRef }: ChatComponentProps = {}) {
+export function Chat({
+  isAuthenticated,
+  onAuthRequired,
+  handleStopRef,
+  hasReceivedInit = true,
+}: ChatComponentProps = {}) {
   renderLogger.trace('Chat');
 
+  /*
+   * useGitbaseChatHistory는 항상 호출 (React 훅 규칙)
+   * hasReceivedInit을 전달하여 내부에서 조건 처리
+   */
   const {
     loaded,
     loading,
@@ -229,7 +239,7 @@ export function Chat({ isAuthenticated, onAuthRequired, handleStopRef }: ChatCom
     loadBefore,
     loadingBefore,
     error: gitbaseError,
-  } = useGitbaseChatHistory();
+  } = useGitbaseChatHistory(hasReceivedInit);
 
   const [componentError, setComponentError] = useState<{
     message: string;

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -220,10 +220,6 @@ export function Chat({
 }: ChatComponentProps = {}) {
   renderLogger.trace('Chat');
 
-  /*
-   * useGitbaseChatHistory는 항상 호출 (React 훅 규칙)
-   * hasReceivedInit을 전달하여 내부에서 조건 처리
-   */
   const {
     loaded,
     loading,

--- a/app/lib/persistenceGitbase/useGitbaseChatHistory.ts
+++ b/app/lib/persistenceGitbase/useGitbaseChatHistory.ts
@@ -260,9 +260,9 @@ export function useGitbaseChatHistory(hasReceivedInit: boolean = true) {
   }, [loading, hasMore, currentPage, load]);
 
   useEffect(() => {
-    // hasReceivedInit이 false면 API 호출 스킵
+    // Skip API calls if not ready
     if (!hasReceivedInit || !projectPath) {
-      // 기본 상태로 설정
+      // Set default state
       setLoaded(true);
       setFilesLoaded(true);
       setChats([]);

--- a/app/lib/persistenceGitbase/useGitbaseChatHistory.ts
+++ b/app/lib/persistenceGitbase/useGitbaseChatHistory.ts
@@ -46,7 +46,7 @@ interface CommitResponse {
   error?: string;
 }
 
-export function useGitbaseChatHistory() {
+export function useGitbaseChatHistory(hasReceivedInit: boolean = true) {
   const projectPath = repoStore.get().path;
   const [project, setProject] = useState<{
     id: string;
@@ -260,6 +260,17 @@ export function useGitbaseChatHistory() {
   }, [loading, hasMore, currentPage, load]);
 
   useEffect(() => {
+    // hasReceivedInit이 false면 API 호출 스킵
+    if (!hasReceivedInit || !projectPath) {
+      // 기본 상태로 설정
+      setLoaded(true);
+      setFilesLoaded(true);
+      setChats([]);
+      setFiles({});
+
+      return undefined;
+    }
+
     const unsubscribe = repoStore.subscribe((state) => {
       if (
         projectPath !== prevRequestParams.current.projectPath ||
@@ -268,8 +279,9 @@ export function useGitbaseChatHistory() {
         load({ page: 1, taskBranch: state.taskBranch, untilCommit: undefined });
       }
     });
+
     return () => unsubscribe();
-  }, [load, projectPath]);
+  }, [load, projectPath, hasReceivedInit]);
 
   return {
     loaded: loaded && filesLoaded,

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -52,7 +52,7 @@ function AccessControlledChat() {
   const handleStopRef = useRef<(() => void) | null>(null);
   const [hasReceivedInit, setHasReceivedInit] = useState<boolean>(false);
 
-  // localStorage에 토큰이 있으면 바로 준비 완료 상태로 시작
+  // Start immediately if token exists in localStorage
   const [isReady, setIsReady] = useState<boolean>(!!accessToken);
 
   // Helper function to send postMessage to allowed parent origins
@@ -125,7 +125,7 @@ function AccessControlledChat() {
           hasToken: !!token,
         });
 
-        // INIT 메시지를 받았으므로 준비 완료
+        // Mark as ready after receiving INIT message
         setHasReceivedInit(true);
         setIsReady(true);
 
@@ -164,14 +164,14 @@ function AccessControlledChat() {
 
     window.addEventListener('message', handleMessage);
 
-    // 5초 타임아웃 후에도 INIT이 안 오면 준비 완료 상태로 진행
+    // Start after 5 second timeout even if INIT is not received
     const timeout = setTimeout(() => {
       if (isLoading && !accessToken) {
         setIsLoading(false);
         setIsActivated(false);
       }
 
-      // INIT을 받지 못했더라도 타임아웃 후 준비 완료
+      // Mark as ready after timeout even without INIT
       if (!hasReceivedInit) {
         setIsReady(true);
       }


### PR DESCRIPTION
- Add hasReceivedInit flag to track INIT message reception
- Skip useGitbaseChatHistory API calls when not ready
- Allow immediate start if localStorage has token
- Prevent transient 401 errors during old UI switch