### PR TITLE
fix: build error when entering commands directly in terminal

### DIFF
--- a/app/lib/container/remote-container.ts
+++ b/app/lib/container/remote-container.ts
@@ -1523,6 +1523,8 @@ export class RemoteContainer implements Container {
             currentTerminal.input(':' + '\n');
           }
 
+          logger.debug(`[${commandExecutionId}] waiting for prompt`, command);
+
           // Wait for prompt
           await waitTillOscCode('prompt');
 

--- a/app/lib/container/remote-container.ts
+++ b/app/lib/container/remote-container.ts
@@ -48,6 +48,12 @@ const BUFFER_CONFIG = {
   TRUNCATED_LOCAL_SIZE: 5000,
 };
 
+// Drain buffer configuration
+const DRAIN_BUFFER_CONFIG = {
+  MAX_TIMEOUT_MS: 500,
+  READ_TIMEOUT_MS: 200,
+};
+
 const STREAM_READ_IDLE_TIMEOUT_MS = 3000;
 
 const ROUTER_DOMAIN = 'agent8.verse8.net';
@@ -1445,17 +1451,48 @@ export class RemoteContainer implements Container {
       output = streams[0];
       internalOutput = streams[1];
 
+      /**
+       * Drain all data from internal stream buffer until empty
+       * Uses single timeout approach: if no data arrives within 200ms, stream is considered empty
+       * @param maxTimeMs - Maximum time to spend draining
+       */
+      const drainAllBuffer = async (maxTimeMs: number): Promise<void> => {
+        if (!internalOutput || internalOutput.locked) {
+          return;
+        }
+
+        const reader = internalOutput.getReader();
+        const deadline = Date.now() + maxTimeMs;
+
+        try {
+          while (Date.now() < deadline) {
+            const result = await Promise.race([
+              reader.read(),
+              new Promise<ReadableStreamReadResult<string>>((resolve) => {
+                setTimeout(() => resolve({ done: true, value: undefined }), DRAIN_BUFFER_CONFIG.READ_TIMEOUT_MS);
+              }),
+            ]);
+
+            if (result.done || !result.value) {
+              break;
+            }
+          }
+        } catch (error) {
+          logger.error('drainAllBuffer: Error:', error);
+        } finally {
+          reader.releaseLock();
+        }
+      };
+
       // Command execution implementation
       executeCommand = async (command: string): Promise<ExecutionResult> => {
-        // Command execution ID for logging (not a session ID)
         const commandExecutionId = v4().slice(0, 8);
-        logger.debug(`[${commandExecutionId}] executeCommand`, command);
+        logger.debug(`[${commandExecutionId}] executeCommand: ${command}`);
 
         // Set non-terminating process flag for timeout handling
         if (isNonTerminatingCommand(command)) {
           nonTerminatingProcessRunning = true;
         } else {
-          // Clear any existing timeout from previous non-terminating command
           if (readSetTimeoutId) {
             clearTimeout(readSetTimeoutId);
             readSetTimeoutId = null;
@@ -1465,10 +1502,12 @@ export class RemoteContainer implements Container {
         }
 
         try {
-          // Use currentTerminal instead of original terminal for input
           if (!currentTerminal) {
             throw new Error('No terminal attached to session');
           }
+
+          // Drain all data from internal stream buffer
+          await drainAllBuffer(DRAIN_BUFFER_CONFIG.MAX_TIMEOUT_MS);
 
           /*
            * Clear global output buffer to avoid confusion with previous command outputs
@@ -1479,21 +1518,20 @@ export class RemoteContainer implements Container {
           // Interrupt current execution
           currentTerminal.input('\x03');
 
-          // for dead lock prevention
+          // Deadlock prevention
           if (isWaitingForOscCode) {
             currentTerminal.input(':' + '\n');
           }
 
-          logger.debug(`[${commandExecutionId}] waiting for prompt`, command);
-
           // Wait for prompt
           await waitTillOscCode('prompt');
 
-          // Execute new command
+          // Execute test command
           currentTerminal.input(':' + '\n');
           await waitTillOscCode('exit');
           logger.debug('terminal is responsive');
 
+          // Execute the actual command
           currentTerminal.input(command.trim() + '\n');
 
           // Wait for execution result
@@ -1504,7 +1542,6 @@ export class RemoteContainer implements Container {
             exitCode,
           };
         } finally {
-          // Always clean up state after command execution (success or failure)
           nonTerminatingProcessRunning = false;
 
           if (readSetTimeoutId) {

--- a/app/lib/container/remote-container.ts
+++ b/app/lib/container/remote-container.ts
@@ -1526,7 +1526,7 @@ export class RemoteContainer implements Container {
           // Wait for prompt
           await waitTillOscCode('prompt');
 
-          // Execute test command
+          // Execute new command
           currentTerminal.input(':' + '\n');
           await waitTillOscCode('exit');
           logger.debug('terminal is responsive');

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -600,6 +600,11 @@ export class WorkbenchStore {
   }
 
   abortAllActions() {
+    // Assign to variables to prevent race conditions
+    const runPreview = this.#runPreviewAbortController;
+    const publish = this.#publishAbortController;
+    const shell = this.#shellAbortController;
+
     // Process and clear all message action queues
     const queueSnapshot = new Map(this.#messageToActionQueue);
     this.#messageToActionQueue.clear();
@@ -642,13 +647,13 @@ export class WorkbenchStore {
       }
     }
 
-    this.#runPreviewAbortController?.abort();
-    this.#publishAbortController?.abort();
-    this.#shellAbortController?.abort();
-
     this.#runPreviewAbortController = null;
     this.#publishAbortController = null;
     this.#shellAbortController = null;
+
+    runPreview?.abort();
+    publish?.abort();
+    shell?.abort();
 
     this.#shellCommandQueue = Promise.resolve();
   }
@@ -1417,7 +1422,14 @@ export class WorkbenchStore {
 
       const { verseId } = await this.setupDeployConfig(shell, signal);
       checkAborted();
-      await this.commitModifiedFiles(signal);
+
+      try {
+        await this.commitModifiedFiles(signal);
+        checkAborted();
+      } catch (error) {
+        failedReason = 'commit failed';
+        throw error;
+      }
       checkAborted();
 
       const container = await this.container;
@@ -1428,9 +1440,15 @@ export class WorkbenchStore {
       const buildResult = await this.#runShellCommand(shell, `${SHELL_COMMANDS.BUILD_PROJECT} --base ./`, signal);
       checkAborted();
 
-      if (buildResult?.exitCode === 2) {
-        this.#handleBuildError(buildResult.output);
-        return;
+      const buildExitCode = buildResult?.exitCode;
+
+      if (buildExitCode !== 0) {
+        if (buildExitCode === 2) {
+          this.#handleBuildError(buildResult.output);
+        }
+
+        failedReason = `build failed`;
+        throw new Error(`${failedReason}: ${buildResult.output}`);
       }
 
       const wc = await this.container;
@@ -1469,8 +1487,16 @@ export class WorkbenchStore {
       }
       checkAborted();
 
-      const { tags } = await getTags(repoStore.get().path);
-      checkAborted();
+      let tags = [] as any[];
+
+      try {
+        const tagsResponse = await getTags(repoStore.get().path);
+        tags = tagsResponse.tags || [];
+        checkAborted();
+      } catch (error) {
+        failedReason = 'get tags failed';
+        throw error;
+      }
 
       const spinTag = tags.find((tag: any) => tag.name.startsWith('verse-from'));
       let parentVerseId;
@@ -1521,8 +1547,6 @@ export class WorkbenchStore {
   }
 
   #handleBuildError(output: string) {
-    logger.error('[Publish] Build Failed:', output);
-
     const alert = {
       type: 'build',
       title: 'Build Error',


### PR DESCRIPTION
Close: https://github.com/planetarium/agent8/issues/770

Fixed an issue where leftover output buffers from previous commands interfered with new command execution results when entering commands directly in the terminal.

Key changes:
- Add drainAllBuffer function to clear stream buffer before command execution
- Prevent AbortController race condition by adjusting abort call order
- Improve error tracking for build, commit, and getTags failures