### PR TITLE
fix: disable attachment tooltip on mobile to prevent touch interference

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -685,6 +685,11 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
     };
 
     const shouldShowAttachmentTooltip = () => {
+      // Disable tooltip on mobile (only show on desktop hover)
+      if (isSmallViewport) {
+        return false;
+      }
+
       return attachmentHovered && !attachmentDropdownOpen && !importProjectModalOpen;
     };
 


### PR DESCRIPTION
- Add isSmallViewport check to shouldShowAttachmentTooltip
- Prevent tooltip from appearing on touch events on mobile devices