### PR TITLE
fix: increase ModelSelector dropdown z-index to appear above MCP dropdown

### DIFF
--- a/app/components/chat/ModelSelector.tsx
+++ b/app/components/chat/ModelSelector.tsx
@@ -297,7 +297,7 @@ export const ModelSelector = ({
 
         {isDropdownOpen && (
           <div
-            className="absolute z-10 bottom-full mb-1 py-1 min-w-[300px] rounded-lg border border-bolt-elements-borderColor bg-[var(--color-bg-interactive-neutral,#222428)] shadow-lg"
+            className="absolute z-[1000] bottom-full mb-1 py-1 min-w-[300px] rounded-lg border border-bolt-elements-borderColor bg-[var(--color-bg-interactive-neutral,#222428)] shadow-lg"
             role="listbox"
             id="model-listbox"
           >


### PR DESCRIPTION
- Change z-index from z-10 to z-[1000]
- Ensures model selector appears above MCP server manager dropdown (z-[999])
- Fixes dropdown stacking order issue