### PR TITLE
refactor: update shell commands to include server build step

### DIFF
--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -1353,14 +1353,14 @@ export class WorkbenchStore {
       if (localStorage.getItem(SETTINGS_KEYS.AGENT8_DEPLOY) === 'false') {
         await this.#runShellCommand(
           shell,
-          `${SHELL_COMMANDS.UPDATE_DEPENDENCIES} && ${SHELL_COMMANDS.START_DEV_SERVER}`,
+          `${SHELL_COMMANDS.UPDATE_DEPENDENCIES} && ${SHELL_COMMANDS.BUILD_SERVER} && ${SHELL_COMMANDS.START_DEV_SERVER}`,
           signal,
         );
         checkAborted();
       } else {
         await this.#runShellCommand(
           shell,
-          `${SHELL_COMMANDS.UPDATE_DEPENDENCIES} && npx -y @agent8/deploy --preview && ${SHELL_COMMANDS.START_DEV_SERVER}`,
+          `${SHELL_COMMANDS.UPDATE_DEPENDENCIES} && ${SHELL_COMMANDS.BUILD_SERVER} && npx -y @agent8/deploy --preview && ${SHELL_COMMANDS.START_DEV_SERVER}`,
           signal,
         );
         checkAborted();
@@ -1437,7 +1437,11 @@ export class WorkbenchStore {
       checkAborted();
 
       // Build project
-      const buildResult = await this.#runShellCommand(shell, `${SHELL_COMMANDS.BUILD_PROJECT} --base ./`, signal);
+      const buildResult = await this.#runShellCommand(
+        shell,
+        `${SHELL_COMMANDS.BUILD_PROJECT} --base ./ && ${SHELL_COMMANDS.BUILD_SERVER}`,
+        signal,
+      );
       checkAborted();
 
       const buildExitCode = buildResult?.exitCode;
@@ -1532,11 +1536,11 @@ export class WorkbenchStore {
     this.#shellCommandQueue = this.#shellCommandQueue.then(async () => {
       checkAborted();
 
-      const result = await shell.executeCommand(Date.now().toString(), command, undefined, { signal });
+      const result = await shell.executeCommand(Date.now().toString(), command, undefined);
 
       checkAborted();
 
-      await shell.waitTillOscCode('prompt', signal);
+      await shell.waitTillOscCode('prompt');
 
       checkAborted();
 

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -1536,11 +1536,11 @@ export class WorkbenchStore {
     this.#shellCommandQueue = this.#shellCommandQueue.then(async () => {
       checkAborted();
 
-      const result = await shell.executeCommand(Date.now().toString(), command, undefined);
+      const result = await shell.executeCommand(Date.now().toString(), command, undefined, { signal });
 
       checkAborted();
 
-      await shell.waitTillOscCode('prompt');
+      await shell.waitTillOscCode('prompt', signal);
 
       checkAborted();
 

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -122,6 +122,7 @@ export const SHELL_COMMANDS = {
   UPDATE_DEPENDENCIES: 'bun update',
   START_DEV_SERVER: 'bun run dev',
   BUILD_PROJECT: 'bun run build',
+  BUILD_SERVER: 'npx -y @agent8/gameserver-node build',
 } as const;
 
 export const REACT_THREE_FIBER_PACKAGE_NAME = '@react-three/fiber';


### PR DESCRIPTION
Close: https://github.com/planetarium/agent8/issues/804

- Modified shell command sequences in WorkbenchStore to incorporate the new BUILD_SERVER command, ensuring the server is built before starting the development server.
- Updated constants to define the BUILD_SERVER command for better project structure.