### PR TITLE
feat: implement access restriction for blocked users on prompt requests

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -73,9 +73,9 @@ import { useVersionFeature } from '~/lib/hooks/useVersionFeature';
 import type { WorkbenchStore } from '~/lib/stores/workbench';
 import type { ServerErrorData } from '~/types/stream-events';
 import { getEnvContent } from '~/utils/envUtils';
-import { V8_ACCESS_TOKEN_KEY, verifyV8AccessToken } from '~/lib/verse8/userAuth';
+import { DENY_ACTIONS, V8_ACCESS_TOKEN_KEY, verifyV8AccessToken } from '~/lib/verse8/userAuth';
 import { logManager } from '~/lib/debug/LogManager';
-import { FetchError, getErrorStatus, isAbortError, isNetworkError } from '~/utils/errors';
+import { AppError, FetchError, StatusCodeError, getErrorStatus, isAbortError, isNetworkError } from '~/utils/errors';
 import { getTurnstileHeaders, clearTurnstileTokenCache } from '~/lib/turnstile/client';
 import { isMobileOS } from '~/utils/mobile';
 
@@ -1173,13 +1173,12 @@ export const ChatImpl = memo(
       });
     };
 
-    /**
-     * Initializes the first chat session with template selection and project setup.
-     * This function can be aborted via AbortSignal.
-     */
     const prepareFirstChat = async (
       messageContent: string,
-      currentAttachmentList: ChatAttachment[],
+      attachmentList: ChatAttachment[],
+      userIsActivated: boolean,
+      userWalletAddress: string,
+      accessToken: string,
       signal: AbortSignal,
     ): Promise<void> => {
       const checkAborted = () => {
@@ -1188,14 +1187,6 @@ export const ChatImpl = memo(
         }
       };
 
-      const accessToken = localStorage.getItem(V8_ACCESS_TOKEN_KEY);
-
-      if (!accessToken) {
-        throw new Error('Access token is missing');
-      }
-
-      let userIsActivated = false;
-      let userWalletAddress = null;
       let starterTemplateResp: any;
 
       try {
@@ -1210,14 +1201,6 @@ export const ChatImpl = memo(
           },
         ]);
 
-        checkAborted();
-        addDebugLog('Start:verifyV8AccessToken');
-
-        const user = await verifyV8AccessToken(import.meta.env.VITE_V8_AUTH_API_ENDPOINT, accessToken, signal);
-        userIsActivated = user.isActivated;
-        userWalletAddress = user.walletAddress;
-
-        addDebugLog('Complete:verifyV8AccessToken');
         checkAborted();
 
         addDebugLog('Start:selectStarterTemplate');
@@ -1381,7 +1364,7 @@ export const ChatImpl = memo(
               {
                 type: 'text',
                 text: `[Model: ${firstChatModel.model}]\n\n[Provider: ${firstChatModel.provider.name}]\n\n[Attachments: ${JSON.stringify(
-                  currentAttachmentList,
+                  attachmentList,
                 )}]\n\n${messageContent}\n<think>${starterPrompt}</think>`,
               },
             ],
@@ -1795,9 +1778,37 @@ export const ChatImpl = memo(
           }
         }
 
+        // Get access token from localStorage
+        const accessToken = localStorage.getItem(V8_ACCESS_TOKEN_KEY);
+
+        if (!accessToken) {
+          throw new StatusCodeError('No access token found', 401);
+        }
+
+        addDebugLog('Start:verifyV8AccessToken');
+
+        const user = await verifyV8AccessToken(import.meta.env.VITE_V8_AUTH_API_ENDPOINT, accessToken, signal);
+        addDebugLog('Complete:verifyV8AccessToken');
+        checkAborted();
+
+        if (user.deny.includes(DENY_ACTIONS.PROMPT)) {
+          throw new StatusCodeError(
+            'Your account is currently restricted. Connect your Google account to continue.',
+            403,
+            { sendChatError: false },
+          );
+        }
+
         if (wasFirstChat) {
           addDebugLog('Start:prepareFirstChat');
-          await prepareFirstChat(messageContent, attachmentList, signal);
+          await prepareFirstChat(
+            messageContent,
+            attachmentList,
+            user.isActivated,
+            user.walletAddress,
+            accessToken,
+            signal,
+          );
           addDebugLog('Complete:prepareFirstChat');
 
           return;
@@ -1903,11 +1914,17 @@ export const ChatImpl = memo(
           displayMessage = 'Error:' + (error instanceof Error ? error.message : String(error));
         }
 
-        processError(displayMessage, chatRequestStartTimeRef.current, {
+        const errorOptions: HandleChatErrorOptions = {
           error: errorObj,
           context,
           toastType,
-        });
+        };
+
+        if (error instanceof AppError && error.sendChatError !== undefined) {
+          errorOptions.sendChatError = error.sendChatError;
+        }
+
+        processError(displayMessage, chatRequestStartTimeRef.current, errorOptions);
       } finally {
         if (sendMessageAbortControllerRef.current === requestController) {
           sendMessageAbortControllerRef.current = null;

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -1914,17 +1914,12 @@ export const ChatImpl = memo(
           displayMessage = 'Error:' + (error instanceof Error ? error.message : String(error));
         }
 
-        const errorOptions: HandleChatErrorOptions = {
+        processError(displayMessage, chatRequestStartTimeRef.current, {
           error: errorObj,
           context,
           toastType,
-        };
-
-        if (error instanceof AppError && error.sendChatError !== undefined) {
-          errorOptions.sendChatError = error.sendChatError;
-        }
-
-        processError(displayMessage, chatRequestStartTimeRef.current, errorOptions);
+          sendChatError: error instanceof AppError ? error.sendChatError : undefined,
+        });
       } finally {
         if (sendMessageAbortControllerRef.current === requestController) {
           sendMessageAbortControllerRef.current = null;

--- a/app/components/sidebar/Menu.client.tsx
+++ b/app/components/sidebar/Menu.client.tsx
@@ -179,9 +179,6 @@ export const Menu = () => {
         <div className="h-13.5 flex items-center justify-between px-4 border-b border-gray-100 dark:border-gray-800/50 bg-gray-50/50 dark:bg-gray-900/50">
           <div className="text-gray-900 dark:text-white font-medium"></div>
           <div className="flex flex-col items-end">
-            <span className="font-medium text-sm text-gray-900 dark:text-white truncate">
-              {v8Auth.loading ? 'Loading...' : v8Auth.user?.name || 'Guest User'}
-            </span>
             {v8Auth.user?.email && (
               <span className="text-xs text-gray-500 dark:text-gray-400 truncate">{v8Auth.user.email}</span>
             )}

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -28,7 +28,7 @@ import {
   getLastCommitHash,
   getTags,
 } from '~/lib/persistenceGitbase/api.client';
-import { V8_ACCESS_TOKEN_KEY, verifyV8AccessToken, type V8User } from '~/lib/verse8/userAuth';
+import { DENY_ACTIONS, V8_ACCESS_TOKEN_KEY, verifyV8AccessToken, type V8User } from '~/lib/verse8/userAuth';
 import { generateVerseId } from '~/utils/envUtils';
 import type { BoltShell } from '~/utils/shell';
 import { SETTINGS_KEYS } from './settings';
@@ -1270,18 +1270,17 @@ export class WorkbenchStore {
     const accessToken = localStorage.getItem(V8_ACCESS_TOKEN_KEY);
 
     if (!accessToken) {
-      throw new Error('No access token found');
+      throw new StatusCodeError('No access token found', 401);
     }
 
     checkAborted();
 
     // Verify user
     const user = await verifyV8AccessToken(import.meta.env.VITE_V8_AUTH_API_ENDPOINT, accessToken, signal);
-
     checkAborted();
 
     if (!user.isActivated) {
-      throw new Error('Account is not activated');
+      throw new StatusCodeError('Account is not activated', 403);
     }
 
     checkAborted();

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -28,7 +28,7 @@ import {
   getLastCommitHash,
   getTags,
 } from '~/lib/persistenceGitbase/api.client';
-import { DENY_ACTIONS, V8_ACCESS_TOKEN_KEY, verifyV8AccessToken, type V8User } from '~/lib/verse8/userAuth';
+import { V8_ACCESS_TOKEN_KEY, verifyV8AccessToken, type V8User } from '~/lib/verse8/userAuth';
 import { generateVerseId } from '~/utils/envUtils';
 import type { BoltShell } from '~/utils/shell';
 import { SETTINGS_KEYS } from './settings';

--- a/app/lib/verse8/api.ts
+++ b/app/lib/verse8/api.ts
@@ -41,7 +41,6 @@ export interface VerseData {
   userUid: string;
   userDisplayName: string;
   userHandle: string;
-  userProfilePicture: string;
   isOwner: boolean;
 }
 

--- a/app/lib/verse8/userAuth.ts
+++ b/app/lib/verse8/userAuth.ts
@@ -3,15 +3,16 @@ import { FetchError } from '~/utils/errors';
 
 export const V8_ACCESS_TOKEN_KEY = 'v8AccessToken';
 
+export const DENY_ACTIONS = {
+  PROMPT: 'prompt',
+} as const;
+
 export interface V8User {
   userUid: string;
   isActivated: boolean;
   email: string;
   walletAddress: string;
-  name: string;
-  profilePicture: string | null;
-  userAddress?: string;
-  role?: string;
+  deny: string[];
 }
 
 export const updateV8AccessToken = (v8AccessToken: string) => {
@@ -45,9 +46,6 @@ export const verifyV8AccessToken = async (
     isActivated: data?.isActivated || true,
     email: data?.email || '',
     walletAddress: data?.walletAddress || '',
-    name: data?.name || '',
-    profilePicture: data?.profilePicture || null,
-    userAddress: data?.userAddress || '',
-    role: data?.role || '',
+    deny: Array.isArray(data?.deny) ? data.deny : [],
   };
 };

--- a/app/lib/verse8/userAuth.ts
+++ b/app/lib/verse8/userAuth.ts
@@ -42,10 +42,10 @@ export const verifyV8AccessToken = async (
   const data = (await response.json()) as Record<string, any>;
 
   return {
-    userUid: data?.userUid || data?.userAddress || '',
-    isActivated: data?.isActivated || true,
-    email: data?.email || '',
-    walletAddress: data?.walletAddress || '',
+    userUid: data?.userUid ?? data?.userAddress,
+    isActivated: data?.isActivated ?? true,
+    email: data?.email ?? '',
+    walletAddress: data?.walletAddress ?? '',
     deny: Array.isArray(data?.deny) ? data.deny : [],
   };
 };

--- a/app/utils/errors.ts
+++ b/app/utils/errors.ts
@@ -1,64 +1,88 @@
 import axios from 'axios';
 
 /**
+ * Application error class with notification control
+ * All custom errors should extend this to support sendChatError flag
+ */
+export class AppError extends Error {
+  readonly sendChatError?: boolean;
+  readonly name: string = 'AppError';
+
+  constructor(message: string, options?: { sendChatError?: boolean }) {
+    super(message);
+    this.sendChatError = options?.sendChatError;
+  }
+}
+
+/**
  * Custom error class for fetch/HTTP errors with status code
  */
-export class FetchError extends Error {
+export class FetchError extends AppError {
+  readonly name: string = 'FetchError';
+
   constructor(
     message: string,
     public status: number,
     public context?: string,
+    options?: { sendChatError?: boolean },
   ) {
-    super(message);
-    this.name = 'FetchError';
+    super(message, options);
   }
 }
 
 export class SkipToastError extends FetchError {
+  readonly name: string = 'SkipToastError';
+
   constructor(
     message: string,
     public status: number,
     public context?: string,
+    options?: { sendChatError?: boolean },
   ) {
-    super(message, status, context);
-    this.name = 'SkipToastError';
+    super(message, status, context, options);
   }
 }
 
-export class DeployError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'DeployError';
+export class DeployError extends AppError {
+  readonly name: string = 'DeployError';
+
+  constructor(message: string, options?: { sendChatError?: boolean }) {
+    super(message, options);
   }
 }
 
 /**
  * Error thrown when LLM repeats a previous response (tool-input-start detected)
  */
-export class LLMRepeatResponseError extends Error {
-  constructor(message: string = 'llm-repeat-response') {
-    super(message);
-    this.name = 'LLMRepeatResponseError';
+export class LLMRepeatResponseError extends AppError {
+  readonly name: string = 'LLMRepeatResponseError';
+
+  constructor(message: string = 'llm-repeat-response', options?: { sendChatError?: boolean }) {
+    super(message, options);
   }
 }
 
-export class StatusCodeError extends Error {
+export class StatusCodeError extends AppError {
+  readonly name: string = 'StatusCodeError';
+
   constructor(
     message: string = 'Status code error',
     public status: number,
+    options?: { sendChatError?: boolean },
   ) {
-    super(message);
-    this.name = 'StatusCodeError';
+    super(message, options);
   }
 }
 
 export class MachineAPIError extends StatusCodeError {
+  readonly name: string = 'MachineAPIError';
+
   constructor(
     message: string = 'Machine API error',
     public status: number,
+    options?: { sendChatError?: boolean },
   ) {
-    super(message, status);
-    this.name = 'MachineAPIError';
+    super(message, status, options);
   }
 }
 
@@ -80,10 +104,11 @@ export function isAbortError(error: unknown): boolean {
   return false;
 }
 
-export class NoneError extends Error {
-  constructor(message: string = 'None error') {
-    super(message);
-    this.name = 'NoneError';
+export class NoneError extends AppError {
+  readonly name: string = 'NoneError';
+
+  constructor(message: string = 'None error', options?: { sendChatError?: boolean }) {
+    super(message, options);
   }
 }
 


### PR DESCRIPTION
Close: https://github.com/planetarium/agent8/issues/782

- Add user authentication and block status verification before prompt submission
- Handle 403 error for users blocked by DENY_ACTIONS.PROMPT
- Improve error class structure based on AppError (support sendChatError flag)
- Optimize first chat preparation logic (improve user info passing)
- Remove unnecessary UI elements (sidebar user name display)
- Add deny field to V8User interface