### PR TITLE
fix: add empty template fallback and update model configurations

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -1264,7 +1264,7 @@ export const ChatImpl = memo(
         const temResp = await fetchTemplateFromAPI(
           starterTemplateResp.template!,
           starterTemplateResp.title,
-          starterTemplateResp.projectRepo,
+          starterTemplateResp.projectRepo || 'basic-project',
           signal,
         ).catch((e) => {
           checkAborted();

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -41,8 +41,12 @@ export const FIXED_MODELS = {
       model: 'gemini-2.5-flash',
     },
     {
+      provider: PROVIDER_LIST.find((p) => p.name === PROVIDER_NAMES.OPEN_ROUTER)!,
+      model: 'openai/gpt-5-mini',
+    },
+    {
       provider: PROVIDER_LIST.find((p) => p.name === PROVIDER_NAMES.GOOGLE_VERTEX_AI)!,
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3-flash-preview',
     },
   ],
   PROMPT_ENHANCER_TEMPLATE: {


### PR DESCRIPTION
Close: #824 

- Add 'basic-project' fallback when projectRepo is empty in starter template fetch
- Add OpenRouter gpt-5-mini to fixed model list
- Update Gemini model from gemini-2.5-flash to gemini-3-flash-preview