### PR TITLE
build(vite): remove Sentry source map upload configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -96,8 +96,6 @@ export default defineConfig((config) => {
     },
     build: {
       target: 'esnext',
-      // Generate source maps for Sentry (hidden from browser)
-      sourcemap: config.mode === 'production' ? 'hidden' : true,
       rollupOptions: {
         output: {
           format: 'esm',
@@ -160,38 +158,6 @@ export default defineConfig((config) => {
       chrome129IssuePlugin(),
       chromeDevtoolsPlugin(),
       config.mode === 'production' && optimizeCssModules({ apply: 'build' }),
-      
-      // Sentry Vite Plugin - uploads source maps to Sentry in production builds
-      config.mode === 'production' &&
-        !!process.env.SENTRY_AUTH_TOKEN &&
-        sentryVitePlugin({
-          org: process.env.SENTRY_ORG,
-          project: process.env.SENTRY_PROJECT,
-          authToken: process.env.SENTRY_AUTH_TOKEN,
-          
-          // Release configuration
-          release: {
-            name: `agent8@${gitInfo.commitHash}`,
-            setCommits: {
-              auto: true,
-              ignoreMissing: true,
-            },
-          },
-          
-          // Source maps configuration
-          sourcemaps: {
-            // Upload all build artifacts
-            assets: ['./build/**'],
-            // Delete source maps after upload (security)
-            filesToDeleteAfterUpload: ['./build/**/*.map'],
-          },
-          
-          // Telemetry
-          telemetry: false,
-          
-          // Silent mode in CI
-          silent: !!process.env.CI,
-        }),
     ],
     envPrefix: [
       'VITE_',


### PR DESCRIPTION
Remove sentryVitePlugin and hidden sourcemap generation from vite config.
Source map upload to Sentry is no longer required in production builds.