### PR TITLE
feat: prevent duplicate calls to search_file_contents tool

### DIFF
--- a/app/lib/.server/llm/constants.ts
+++ b/app/lib/.server/llm/constants.ts
@@ -24,6 +24,7 @@ export type FileMap = Record<string, Dirent | undefined>;
 export type Orchestration = {
   readSet: Set<string>;
   updatedSet: Set<string>;
+  searchSet: Set<string>;
 };
 
 export const TOOL_ERROR = {

--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -48,7 +48,7 @@ export type Messages = UIMessage[];
 export type StreamingOptions = Omit<Parameters<typeof _streamText>[0], 'model' | 'messages' | 'prompt' | 'system'>;
 
 function createOrchestration(): Orchestration {
-  return { readSet: new Set(), updatedSet: new Set() };
+  return { readSet: new Set(), updatedSet: new Set(), searchSet: new Set() };
 }
 
 const logger = createScopedLogger('stream-text');
@@ -198,7 +198,7 @@ export async function streamText(props: {
     // Add file search tools
     combinedTools = {
       ...combinedTools,
-      [TOOL_NAMES.SEARCH_FILE_CONTENTS]: createFileContentSearchTool(files),
+      [TOOL_NAMES.SEARCH_FILE_CONTENTS]: createFileContentSearchTool(files, orchestration),
       [TOOL_NAMES.READ_FILES_CONTENTS]: createFilesReadTool(files, orchestration),
     };
   }

--- a/app/lib/.server/llm/tools/file-search.ts
+++ b/app/lib/.server/llm/tools/file-search.ts
@@ -27,19 +27,23 @@ export const createFileContentSearchTool = (fileMap: FileMap, orchestration: Orc
     }),
     outputSchema: z.object({
       pattern: z.string(),
-      totalMatches: z.number(),
-      matchingFiles: z.array(
-        z.object({
-          path: z.string(),
-          matches: z.array(
-            z.object({
-              line: z.number(),
-              text: z.string(),
-              contextLines: z.array(z.object({ line: z.number(), text: z.string(), isMatch: z.boolean() })).optional(),
-            }),
-          ),
-        }),
-      ),
+      totalMatches: z.number().optional(),
+      matchingFiles: z
+        .array(
+          z.object({
+            path: z.string(),
+            matches: z.array(
+              z.object({
+                line: z.number(),
+                text: z.string(),
+                contextLines: z
+                  .array(z.object({ line: z.number(), text: z.string(), isMatch: z.boolean() }))
+                  .optional(),
+              }),
+            ),
+          }),
+        )
+        .optional(),
       systemMessage: z.string().optional(),
     }),
     execute: async ({
@@ -53,19 +57,19 @@ export const createFileContentSearchTool = (fileMap: FileMap, orchestration: Orc
       beforeLines?: number;
       afterLines?: number;
     }) => {
-      const result = {
-        pattern,
-        totalMatches: 0,
-        matchingFiles: [] as Array<{
+      const result: {
+        pattern: string;
+        totalMatches?: number;
+        matchingFiles?: Array<{
           path: string;
           matches: Array<{
             line: number;
             text: string;
             contextLines?: Array<{ line: number; text: string; isMatch: boolean }>;
           }>;
-        }>,
-        systemMessage: undefined as string | undefined,
-      };
+        }>;
+        systemMessage?: string;
+      } = { pattern };
 
       const searchPattern = caseSensitive ? pattern : pattern.toLowerCase();
 

--- a/app/lib/.server/llm/tools/file-search.ts
+++ b/app/lib/.server/llm/tools/file-search.ts
@@ -7,10 +7,12 @@ import { tool } from 'ai';
 /**
  * Tool for searching file contents with pattern matching (similar to grep)
  */
-export const createFileContentSearchTool = (fileMap: FileMap) => {
+export const createFileContentSearchTool = (fileMap: FileMap, orchestration: Orchestration) => {
+  const searched = orchestration.searchSet;
+
   return tool({
     description:
-      'READ ONLY TOOL : Search file contents for specific patterns or text, similar to grep. Use this tool when you need to find specific code patterns, variable definitions, or text within files. These tools only provide read functionality and cannot change the state of files. Changes to files should be performed through output, not tool calls.',
+      'READ ONLY TOOL : Search file contents for specific patterns or text, similar to grep. Use this tool when you need to find specific code patterns, variable definitions, or text within files. These tools only provide read functionality and cannot change the state of files. Changes to files should be performed through output, not tool calls. CRITICAL: If the same pattern has already been searched, do not call this tool again with the same pattern.',
     inputSchema: z.object({
       pattern: z.string().describe('Text pattern or regular expression to search for in file content'),
       caseSensitive: z.boolean().optional().describe('Whether the search should be case-sensitive (default: false)'),
@@ -23,6 +25,23 @@ export const createFileContentSearchTool = (fileMap: FileMap) => {
         .optional()
         .describe('Number of lines to include after each match, similar to grep -A option (default: 0)'),
     }),
+    outputSchema: z.object({
+      pattern: z.string(),
+      totalMatches: z.number(),
+      matchingFiles: z.array(
+        z.object({
+          path: z.string(),
+          matches: z.array(
+            z.object({
+              line: z.number(),
+              text: z.string(),
+              contextLines: z.array(z.object({ line: z.number(), text: z.string(), isMatch: z.boolean() })).optional(),
+            }),
+          ),
+        }),
+      ),
+      systemMessage: z.string().optional(),
+    }),
     execute: async ({
       pattern,
       caseSensitive,
@@ -34,20 +53,43 @@ export const createFileContentSearchTool = (fileMap: FileMap) => {
       beforeLines?: number;
       afterLines?: number;
     }) => {
-      const results = searchFileContentsByPattern(fileMap, pattern, caseSensitive, beforeLines, afterLines);
-
-      return {
+      const result = {
         pattern,
-        totalMatches: results.length,
-        matchingFiles: results.map((result) => ({
-          path: result.path.replace(WORK_DIR + '/', ''),
-          matches: result.matches.map((match) => ({
-            line: match.line,
-            text: match.text,
-            contextLines: match.contextLines,
-          })),
-        })),
+        totalMatches: 0,
+        matchingFiles: [] as Array<{
+          path: string;
+          matches: Array<{
+            line: number;
+            text: string;
+            contextLines?: Array<{ line: number; text: string; isMatch: boolean }>;
+          }>;
+        }>,
+        systemMessage: undefined as string | undefined,
       };
+
+      const searchPattern = caseSensitive ? pattern : pattern.toLowerCase();
+
+      if (searched.has(searchPattern)) {
+        result.systemMessage = `⚠️ Pattern "${searchPattern}" was already searched in this conversation. Please refer to the previous search results instead of searching again.`;
+      } else {
+        try {
+          const searchResults = searchFileContentsByPattern(fileMap, pattern, caseSensitive, beforeLines, afterLines);
+          searched.add(searchPattern);
+          result.totalMatches = searchResults.length;
+          result.matchingFiles = searchResults.map((fileResult) => ({
+            path: fileResult.path.replace(WORK_DIR + '/', ''),
+            matches: fileResult.matches.map((match) => ({
+              line: match.line,
+              text: match.text,
+              contextLines: match.contextLines,
+            })),
+          }));
+        } catch (e) {
+          result.systemMessage = `⚠️ Search failed: ${e instanceof Error ? e.message : String(e)}`;
+        }
+      }
+
+      return result;
     },
   });
 };

--- a/app/lib/.server/llm/tools/file-search.ts
+++ b/app/lib/.server/llm/tools/file-search.ts
@@ -12,7 +12,7 @@ export const createFileContentSearchTool = (fileMap: FileMap, orchestration: Orc
 
   return tool({
     description:
-      'READ ONLY TOOL : Search file contents for specific patterns or text, similar to grep. Use this tool when you need to find specific code patterns, variable definitions, or text within files. These tools only provide read functionality and cannot change the state of files. Changes to files should be performed through output, not tool calls. CRITICAL: If the same pattern has already been searched, do not call this tool again with the same pattern.',
+      'READ ONLY TOOL : Search file contents for specific patterns or text, similar to grep. Use this tool when you need to find specific code patterns, variable definitions, or text within files. These tools only provide read functionality and cannot change the state of files. Changes to files should be performed through output, not tool calls.',
     inputSchema: z.object({
       pattern: z.string().describe('Text pattern or regular expression to search for in file content'),
       caseSensitive: z.boolean().optional().describe('Whether the search should be case-sensitive (default: false)'),
@@ -25,27 +25,6 @@ export const createFileContentSearchTool = (fileMap: FileMap, orchestration: Orc
         .optional()
         .describe('Number of lines to include after each match, similar to grep -A option (default: 0)'),
     }),
-    outputSchema: z.object({
-      pattern: z.string(),
-      totalMatches: z.number().optional(),
-      matchingFiles: z
-        .array(
-          z.object({
-            path: z.string(),
-            matches: z.array(
-              z.object({
-                line: z.number(),
-                text: z.string(),
-                contextLines: z
-                  .array(z.object({ line: z.number(), text: z.string(), isMatch: z.boolean() }))
-                  .optional(),
-              }),
-            ),
-          }),
-        )
-        .optional(),
-      systemMessage: z.string().optional(),
-    }),
     execute: async ({
       pattern,
       caseSensitive,
@@ -57,43 +36,45 @@ export const createFileContentSearchTool = (fileMap: FileMap, orchestration: Orc
       beforeLines?: number;
       afterLines?: number;
     }) => {
-      const result: {
-        pattern: string;
-        totalMatches?: number;
-        matchingFiles?: Array<{
-          path: string;
-          matches: Array<{
-            line: number;
-            text: string;
-            contextLines?: Array<{ line: number; text: string; isMatch: boolean }>;
-          }>;
-        }>;
-        systemMessage?: string;
-      } = { pattern };
+      if (!pattern) {
+        return { pattern, systemMessage: '⚠️ Pattern is empty. Please provide a valid pattern to search for.' };
+      }
+
+      if ((beforeLines !== undefined && beforeLines < 0) || (afterLines !== undefined && afterLines < 0)) {
+        return { pattern, systemMessage: '⚠️ Before lines and after lines must be greater than 0.' };
+      }
 
       const searchPattern = caseSensitive ? pattern : pattern.toLowerCase();
 
       if (searched.has(searchPattern)) {
-        result.systemMessage = `⚠️ Pattern "${searchPattern}" was already searched in this conversation. Please refer to the previous search results instead of searching again.`;
-      } else {
-        try {
-          const searchResults = searchFileContentsByPattern(fileMap, pattern, caseSensitive, beforeLines, afterLines);
-          searched.add(searchPattern);
-          result.totalMatches = searchResults.length;
-          result.matchingFiles = searchResults.map((fileResult) => ({
-            path: fileResult.path.replace(WORK_DIR + '/', ''),
-            matches: fileResult.matches.map((match) => ({
-              line: match.line,
-              text: match.text,
-              contextLines: match.contextLines,
-            })),
-          }));
-        } catch (e) {
-          result.systemMessage = `⚠️ Search failed: ${e instanceof Error ? e.message : String(e)}`;
-        }
+        return {
+          pattern,
+          systemMessage: `⚠️ Pattern "${searchPattern}" was already searched in this conversation. Please refer to the previous search results instead of searching again.`,
+        };
       }
 
-      return result;
+      searched.add(searchPattern);
+
+      let searchResults: ReturnType<typeof searchFileContentsByPattern>;
+
+      try {
+        searchResults = searchFileContentsByPattern(fileMap, pattern, caseSensitive, beforeLines, afterLines);
+      } catch {
+        return { pattern, totalMatches: 0, matchingFiles: [] };
+      }
+
+      const sanitizedSearchResults = searchResults
+        .map((fileResult) => ({
+          path: fileResult.path.replace(`${WORK_DIR}/`, ''),
+          matches: fileResult.matches.filter((match) => match.index >= 0),
+        }))
+        .filter((fileResult) => fileResult.path.length > 0 && fileResult.matches.length > 0);
+
+      return {
+        pattern,
+        totalMatches: sanitizedSearchResults.length,
+        matchingFiles: sanitizedSearchResults,
+      };
     },
   });
 };

--- a/app/lib/.server/llm/tools/file-search.ts
+++ b/app/lib/.server/llm/tools/file-search.ts
@@ -41,7 +41,7 @@ export const createFileContentSearchTool = (fileMap: FileMap, orchestration: Orc
       }
 
       if ((beforeLines !== undefined && beforeLines < 0) || (afterLines !== undefined && afterLines < 0)) {
-        return { pattern, systemMessage: '⚠️ Before lines and after lines must be greater than 0.' };
+        return { pattern, systemMessage: '⚠️ Invalid input: beforeLines and afterLines must be ≥ 0' };
       }
 
       const searchPattern = caseSensitive ? pattern : pattern.toLowerCase();


### PR DESCRIPTION
Close: https://github.com/planetarium/agent8/issues/838
-   Add searchSet to Orchestration type and implement deduplication logic in createFileContentSearchTool. 
- Normalize patterns to lowercase to detect case-variant duplicates, handle invalid regex with graceful error response, and define outputSchema for explicit return type validation.