### PR TITLE
fix: display error UI for failed tool executions

### DIFF
--- a/app/components/chat/ToolCall.tsx
+++ b/app/components/chat/ToolCall.tsx
@@ -140,7 +140,11 @@ export const ToolCall = ({ toolCall, id }: ToolCallProps) => {
     toolCall.toolName.toLowerCase().includes(whitelistedTool.toLowerCase()),
   );
 
-  const toolLabel = isToolUseTool ? 'Tool Use' : 'Check';
+  let toolLabel = isToolUseTool ? 'Tool Use' : 'Check';
+
+  if (currentTool.isError) {
+    toolLabel = isToolUseTool ? 'Tool Use Failed' : 'Check Failed';
+  }
 
   const mcpServerName = getMcpServerName(toolCall.toolName);
   const mcpServerDisplayName = getMcpServerDisplayName(toolCall.toolName);
@@ -150,15 +154,30 @@ export const ToolCall = ({ toolCall, id }: ToolCallProps) => {
     <div className="flex items-center gap-2 mt-4">
       <div className="text-[20px]">
         {currentTool.loaded ? (
-          <div style={{ width: '20px', height: '20px' }}>
-            <Lottie animationData={checkCircleAnimationData} loop={false} />
-          </div>
+          currentTool.isError ? (
+            <div
+              style={{ width: '20px', height: '20px', padding: '2.5px' }}
+              className="flex items-center justify-center"
+            >
+              <svg width="15" height="15" viewBox="0 0 20 20" fill="none">
+                <circle cx="10" cy="10" r="9" stroke="#EF4444" strokeWidth="2" fill="none" />
+                <path d="M10 6V11" stroke="#EF4444" strokeWidth="2" strokeLinecap="round" />
+                <circle cx="10" cy="14" r="0.75" fill="#EF4444" />
+              </svg>
+            </div>
+          ) : (
+            <div style={{ width: '20px', height: '20px' }}>
+              <Lottie animationData={checkCircleAnimationData} loop={false} />
+            </div>
+          )
         ) : (
           <div className="i-svg-spinners:90-ring-with-bg text-white"></div>
         )}
       </div>
       <div className="flex items-center gap-1 flex-[1_0_0]">
-        <span className="text-body-sm text-tertiary">{toolLabel}</span>
+        <span className={`text-body-sm ${currentTool.isError ? 'text-danger-bold' : 'text-tertiary'}`}>
+          {toolLabel}
+        </span>
         <div className="flex items-center gap-0.5">
           <img src={iconPath} alt={mcpServerDisplayName || mcpServerName || 'Tool'} className="w-4 h-4" />
           <span className="text-body-sm text-secondary">

--- a/app/components/chat/ToolResult.tsx
+++ b/app/components/chat/ToolResult.tsx
@@ -3,7 +3,6 @@ import { toolUIStore } from '~/lib/stores/toolUI';
 
 export interface ToolResult {
   isError: boolean;
-  error?: string;
   result: any;
 }
 
@@ -22,7 +21,6 @@ export const ToolResult = ({ toolResult, id }: ToolResultProps) => {
           ...currentTool,
           loaded: true,
           isError: toolResult.isError,
-          error: toolResult.error,
         },
       },
     });

--- a/app/components/chat/ToolResult.tsx
+++ b/app/components/chat/ToolResult.tsx
@@ -12,16 +12,21 @@ interface ToolResultProps {
   id: string;
 }
 
-export const ToolResult = ({ id }: ToolResultProps) => {
+export const ToolResult = ({ toolResult, id }: ToolResultProps) => {
   useEffect(() => {
     const currentTool = toolUIStore.get().tools?.[id] || {};
     toolUIStore.set({
       tools: {
         ...toolUIStore.get().tools,
-        [id]: { ...currentTool, loaded: true },
+        [id]: {
+          ...currentTool,
+          loaded: true,
+          isError: toolResult.isError,
+          error: toolResult.error,
+        },
       },
     });
-  }, []);
+  }, [toolResult, id]);
 
   // Just mark as loaded, no UI needed
   return null;

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -647,6 +647,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
                   const toolResult = {
                     toolCallId: chunk.toolCallId,
                     result: chunk.output,
+                    isError: false,
                   };
 
                   const divString = `\n<toolResult><div class="__toolResult__" id="${chunk.toolCallId}">\`${JSON.stringify(toolResult).replaceAll('`', '&grave;')}\`</div></toolResult>\n`;
@@ -679,6 +680,8 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
                   const toolResult = {
                     toolCallId: chunk.toolCallId,
                     result: chunk.errorText,
+                    isError: true,
+                    error: chunk.errorText,
                   };
 
                   const divString = `\n<toolResult><div class="__toolResult__" id="${chunk.toolCallId}">\`${JSON.stringify(toolResult).replaceAll('`', '&grave;')}\`</div></toolResult>\n`;

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -681,7 +681,6 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
                     toolCallId: chunk.toolCallId,
                     result: chunk.errorText,
                     isError: true,
-                    error: chunk.errorText,
                   };
 
                   const divString = `\n<toolResult><div class="__toolResult__" id="${chunk.toolCallId}">\`${JSON.stringify(toolResult).replaceAll('`', '&grave;')}\`</div></toolResult>\n`;


### PR DESCRIPTION
- Add isError field to tool result stream in api.chat.ts
- Store isError and error in toolUIStore via ToolResult component
- Display error icon and "Tool Use Failed" label when tool execution fails