### PR TITLE
fix: detect MCP tool error from result.isError and preserve it on commit

### DIFF
--- a/app/lib/persistenceGitbase/api.client.ts
+++ b/app/lib/persistenceGitbase/api.client.ts
@@ -247,7 +247,16 @@ ${userMessage}
 <V8AssistantMessage>
 ${truncateMessage(
   content
-    .replace(/(<toolResult><div[^>]*?>)(.*?)(<\/div><\/toolResult>)/gs, '$1`{"result":"(truncated)"}`$3')
+    .replace(/(<toolResult><div[^>]*?>)(.*?)(<\/div><\/toolResult>)/gs, (_match, prefix, jsonContent, suffix) => {
+      try {
+        const parsed = JSON.parse(jsonContent.replace(/^`|`$/g, ''));
+        const truncated = { result: '(truncated)', isError: !!parsed.isError };
+
+        return `${prefix}\`${JSON.stringify(truncated)}\`${suffix}`;
+      } catch {
+        return `${prefix}\`{"result":"(truncated)"}\`${suffix}`;
+      }
+    })
     .replace(/(<boltAction type="file"[^>]*>)([\s\S]*?)(<\/boltAction>)/gs, '$1(truncated)$3')
     .replace(/(<boltAction type="modify"[^>]*>)([\s\S]*?)(<\/boltAction>)/gs, '$1(truncated)$3'),
   MAX_ASSISTANT_MESSAGE_SIZE,

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -107,6 +107,7 @@ function toBoltSubmitActionsXML(
 
 export const action = withTurnstile(withV8AuthUser(chatAction, { checkCredit: true }));
 
+const ERROR_FIELD = 'isError';
 const IGNORE_TOOL_TYPES = ['tool-input-start', 'tool-input-delta', 'tool-input-end'];
 const SUBMIT_ACTIONS_TOOLS = [
   TOOL_NAMES.SUBMIT_FILE_ACTION,
@@ -644,10 +645,11 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
                     break;
                   }
 
+                  const isError = !!(chunk.output as any)?.[ERROR_FIELD];
                   const toolResult = {
                     toolCallId: chunk.toolCallId,
                     result: chunk.output,
-                    isError: false,
+                    isError,
                   };
 
                   const divString = `\n<toolResult><div class="__toolResult__" id="${chunk.toolCallId}">\`${JSON.stringify(toolResult).replaceAll('`', '&grave;')}\`</div></toolResult>\n`;


### PR DESCRIPTION
- Read isError from MCP tool output instead of hardcoding false
- Preserve isError field during toolResult truncation in commit storage