### PR TITLE
fix: update chat component logic and message handling

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -1791,6 +1791,7 @@ export const ChatImpl = memo(
           }
         }
 
+        chatStore.setKey('aborted', false);
         setFakeLoading(true);
         runAnimation();
         workbench.currentView.set('preview');
@@ -1876,8 +1877,6 @@ export const ChatImpl = memo(
         if (error != null) {
           setMessages(messages.slice(0, -1));
         }
-
-        chatStore.setKey('aborted', false);
 
         if (repoStore.get().path) {
           checkAborted();

--- a/app/components/chat/Messages.client.tsx
+++ b/app/components/chat/Messages.client.tsx
@@ -393,7 +393,7 @@ export const Messages = forwardRef<HTMLDivElement, MessagesProps>(
                               </>
                             ) : failedMessageIds?.has(messageId ?? '') ? (
                               <span className="text-heading-xs text-danger-bold">Response Failed</span>
-                            ) : isLast && !isAborted ? (
+                            ) : isLast && !isAborted && !isMessageAborted ? (
                               <span
                                 className="text-heading-xs"
                                 style={{


### PR DESCRIPTION
Close: https://github.com/planetarium/agent8/issues/866

- Set 'aborted' key in chatStore to false when initiating chat
- Enhance message rendering logic to account for additional 'isMessageAborted' condition